### PR TITLE
Add Slack notification support to email backend

### DIFF
--- a/web/email_backend.py
+++ b/web/email_backend.py
@@ -1,0 +1,79 @@
+import json
+import logging
+
+import requests
+from django.conf import settings
+from django.core.mail.backends.console import EmailBackend as ConsoleBackend
+
+logger = logging.getLogger(__name__)
+
+
+class SlackNotificationEmailBackend:
+    """
+    Email backend that sends a notification to Slack whenever an email is sent.
+    This is a wrapper around another email backend.
+    """
+
+    def __init__(self, **kwargs):
+        # Determine which backend to use based on settings
+        if settings.DEBUG:
+            self.backend = ConsoleBackend(**kwargs)
+        else:
+            # Use SendGrid backend in production
+            from sendgrid_backend.mail import SendgridBackend
+
+            self.backend = SendgridBackend(**kwargs)
+
+        self.webhook_url = getattr(settings, "EMAIL_SLACK_WEBHOOK", None)
+
+    def open(self):
+        return self.backend.open()
+
+    def close(self):
+        return self.backend.close()
+
+    def send_messages(self, email_messages):
+        # First, send the emails using the wrapped backend
+        sent_count = self.backend.send_messages(email_messages)
+
+        # Then, send notifications to Slack for each email
+        if self.webhook_url and sent_count:
+            for message in email_messages:
+                self._notify_slack(message)
+
+        return sent_count
+
+    def _notify_slack(self, email_message):
+        """Send a notification to Slack about the email."""
+        if not self.webhook_url:
+            return
+
+        try:
+            # Create a message for Slack
+            recipients = ", ".join(email_message.to)
+            subject = email_message.subject
+
+            slack_message = {
+                "blocks": [
+                    {"type": "header", "text": {"type": "plain_text", "text": "📧 Email Sent", "emoji": True}},
+                    {
+                        "type": "section",
+                        "fields": [
+                            {"type": "mrkdwn", "text": f"*To:*\n{recipients}"},
+                            {"type": "mrkdwn", "text": f"*From:*\n{email_message.from_email}"},
+                        ],
+                    },
+                    {"type": "section", "fields": [{"type": "mrkdwn", "text": f"*Subject:*\n{subject}"}]},
+                ]
+            }
+
+            # Send the notification to Slack
+            response = requests.post(
+                self.webhook_url, data=json.dumps(slack_message), headers={"Content-Type": "application/json"}
+            )
+
+            if response.status_code != 200:
+                logger.error(f"Failed to send Slack notification: {response.status_code} {response.text}")
+
+        except Exception as e:
+            logger.exception(f"Error sending Slack notification: {str(e)}")

--- a/web/settings.py
+++ b/web/settings.py
@@ -240,13 +240,13 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Email settings
 if DEBUG:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-    print("Using console email backend for development")
+    EMAIL_BACKEND = "web.email_backend.SlackNotificationEmailBackend"
+    print("Using console email backend with Slack notifications for development")
     DEFAULT_FROM_EMAIL = "noreply@example.com"  # Default for development
     SENDGRID_API_KEY = None  # Not needed in development
 else:
     # Production email settings
-    EMAIL_BACKEND = "sendgrid_backend.SendgridBackend"
+    EMAIL_BACKEND = "web.email_backend.SlackNotificationEmailBackend"
     SENDGRID_API_KEY = env.str("SENDGRID_API_KEY", default=env.str("SENDGRID_PASSWORD", default=""))
     EMAIL_HOST = "smtp.sendgrid.net"
     EMAIL_PORT = 587
@@ -278,6 +278,9 @@ TWITTER_USERNAME = env.str("TWITTER_USERNAME", default="alphaonelabs")
 
 # Slack Integration
 SLACK_WEBHOOK_URL = env.str("SLACK_WEBHOOK_URL", default="")
+
+# Slack webhook for email notifications
+EMAIL_SLACK_WEBHOOK = env.str("EMAIL_SLACK_WEBHOOK", default=SLACK_WEBHOOK_URL)
 
 LANGUAGES = [
     ("en", "English"),


### PR DESCRIPTION
Implement a new email backend that sends notifications to Slack whenever an email is sent. This backend wraps around the existing console and SendGrid email backends, allowing for easy integration in both development and production environments. Update settings to configure the new backend and add a Slack webhook URL for notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced email dispatch by integrating Slack notifications for outgoing messages.
- **Chores**
  - Updated email configuration settings to support Slack webhook integration through a new environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->