### PR TITLE
Added truncate and view on hover feature in user dropdown menu

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -268,8 +268,11 @@
               <div id="user-dropdown"
                    class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 z-50">
                 <div class="px-4 py-2 text-sm text-gray-700 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700">
-                  <div class="font-semibold">{{ user.get_full_name|default:user.username }}</div>
-                  <div class="text-sm text-gray-500 dark:text-gray-400">{{ user.email }}</div>
+                  <div class="font-semibold truncate" title="{{ user.get_full_name }}">
+                    {{ user.get_full_name|default:user.username }}
+                  </div>
+                  <div class="text-sm text-gray-500 dark:text-gray-400 truncate"
+                       title="{{ user.email }}">{{ user.email }}</div>
                 </div>
                 <a href="{% url 'create_course' %}"
                    class="flex items-center space-x-2 px-4 py-3 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">


### PR DESCRIPTION
Currently, in the user dropdown menu, if the username and email are long, the text doesn't truncate and overflows. So, to fix it, I added a truncate feature. If users wish to see their whole email and name, they have to hover over it.
<img width="1470" alt="Screenshot 2025-03-18 at 12 20 26 PM" src="https://github.com/user-attachments/assets/5b0b3900-dbb1-4b54-8fa5-1a740a2101b3" />


https://github.com/user-attachments/assets/4a05a78e-aaf4-446b-943b-66f9f1320699


