### PR TITLE
replace "Teach a Course" card with separate Teach and Learn buttons

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -68,6 +68,8 @@ CSRF_TRUSTED_ORIGINS = [
     "https://www.alphaonelabs.com",
     "http://127.0.0.1:8000",
     "http://localhost:8000",
+    "http://127.0.0.1:8080",
+    "http://localhost:8080",
 ]
 
 # Error handling
@@ -316,20 +318,18 @@ if os.environ.get("DATABASE_URL"):
         }
 
     # Google Cloud Storage settings for media files in production
-    if os.environ.get("GS_BUCKET_NAME"):
+    if os.environ.get("DATABASE_URL") and os.environ.get("GS_BUCKET_NAME"):
         DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
         GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME")
         GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID")
 
         # Get service account file path from .env
-        service_account_filename = env.str("SERVICE_ACCOUNT_FILE")
-        SERVICE_ACCOUNT_FILE = os.path.join(BASE_DIR, service_account_filename)
-        if os.path.exists(SERVICE_ACCOUNT_FILE):
+        SERVICE_ACCOUNT_FILE = env.str("SERVICE_ACCOUNT_FILE", default="")
+        if SERVICE_ACCOUNT_FILE and os.path.exists(SERVICE_ACCOUNT_FILE):
             from google.oauth2 import service_account
-
             GS_CREDENTIALS = service_account.Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE)
         else:
-            print(f"Warning: Service account file not found at {SERVICE_ACCOUNT_FILE}")
+            print(f"Warning: Service account file not found or not specified")
             GS_CREDENTIALS = None
 
         GS_DEFAULT_ACL = "publicRead"

--- a/web/settings.py
+++ b/web/settings.py
@@ -68,8 +68,6 @@ CSRF_TRUSTED_ORIGINS = [
     "https://www.alphaonelabs.com",
     "http://127.0.0.1:8000",
     "http://localhost:8000",
-    "http://127.0.0.1:8080",
-    "http://localhost:8080",
 ]
 
 # Error handling
@@ -318,18 +316,20 @@ if os.environ.get("DATABASE_URL"):
         }
 
     # Google Cloud Storage settings for media files in production
-    if os.environ.get("DATABASE_URL") and os.environ.get("GS_BUCKET_NAME"):
+    if os.environ.get("GS_BUCKET_NAME"):
         DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
         GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME")
         GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID")
 
         # Get service account file path from .env
-        SERVICE_ACCOUNT_FILE = env.str("SERVICE_ACCOUNT_FILE", default="")
-        if SERVICE_ACCOUNT_FILE and os.path.exists(SERVICE_ACCOUNT_FILE):
+        service_account_filename = env.str("SERVICE_ACCOUNT_FILE")
+        SERVICE_ACCOUNT_FILE = os.path.join(BASE_DIR, service_account_filename)
+        if os.path.exists(SERVICE_ACCOUNT_FILE):
             from google.oauth2 import service_account
+
             GS_CREDENTIALS = service_account.Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE)
         else:
-            print(f"Warning: Service account file not found or not specified")
+            print(f"Warning: Service account file not found at {SERVICE_ACCOUNT_FILE}")
             GS_CREDENTIALS = None
 
         GS_DEFAULT_ACL = "publicRead"

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -392,8 +392,9 @@
                       <span class="text-gray-600 dark:text-gray-400">{{ tracker.percentage }}%</span>
                     </div>
                     <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
-                      <div class="bg-{{ tracker.color }} h-3 rounded-full"
-                           style="width: {{ tracker.percentage }}%"></div>
+                      <!-- <div class="bg-{{ tracker.color }} h-3 rounded-full"
+                        style="width: {{ tracker.percentage|float }}%;">
+                      </div>                  -->
                     </div>
                   </div>
                 {% endfor %}
@@ -684,4 +685,4 @@
       </div>
     </div>
   </main>
-{% endblock content %}
+{% endblock content %} 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -360,59 +360,21 @@
         </div>
       </div>
       <div class="md:w-1/3 space-y-6">
-        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-          <h2 class="text-xl font-semibold mb-4">
-            <i class="fa-solid fa-chalkboard-user mr-2"></i>
-            Teach a Course
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-800 shadow-lg">
+          <h2 class="text-xl font-semibold mb-6 text-center text-gray-800 dark:text-gray-200">
+            What would you like to do?
           </h2>
-          <form method="post" class="space-y-4">
-            {% csrf_token %}
-            {% if not user.is_authenticated or not user.profile.is_teacher %}
-              {% if request.user.is_authenticated %}
-                <input type="hidden" name="email" value="{{ user.email }}" />
-              {% else %}
-                <div>
-                  <label for="email" class="block text-sm font-medium mb-1">Email</label>
-                  <input type="email"
-                         id="email"
-                         name="email"
-                         class="block w-full border {% if form.email.errors %}border-red-500 dark:border-red-500{% else %}border-gray-300 dark:border-gray-600{% endif %} rounded p-2 focus:outline-none focus:ring-2 focus:ring-teal-300 dark:focus:ring-teal-800 bg-white dark:bg-gray-800"
-                         placeholder="your.email@example.com"
-                         value="{{ form.email.value|default:'' }}"
-                         required />
-                  {% if form.email.errors %}
-                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ form.email.errors|join:", " }}</p>
-                  {% endif %}
-                </div>
-              {% endif %}
-            {% endif %}
-            <div>
-              <label for="subject" class="block text-sm font-medium mb-1">Subject</label>
-              <input type="text"
-                     id="subject"
-                     name="subject"
-                     class="block w-full border {% if form.subject.errors %}border-red-500 dark:border-red-500{% else %}border-gray-300 dark:border-gray-600{% endif %} rounded p-2 focus:outline-none focus:ring-2 focus:ring-teal-300 dark:focus:ring-teal-800 bg-white dark:bg-gray-800"
-                     placeholder="Your subject to teach"
-                     value="{{ form.subject.value|default:'' }}"
-                     required />
-              {% if form.subject.errors %}
-                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ form.subject.errors|join:", " }}</p>
-              {% endif %}
-            </div>
-            <div>
-              <label for="captcha" class="block text-sm font-medium mb-1">Verification</label>
-              <div class="{% if form.captcha.errors %}border border-red-500 dark:border-red-500 rounded p-2{% endif %}">
-                {{ form.captcha }}
-              </div>
-              {% if form.captcha.errors %}
-                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ form.captcha.errors|join:", " }}</p>
-              {% endif %}
-            </div>
-            <button type="submit"
-                    class="bg-orange-500 hover:bg-orange-600 text-white font-semibold px-4 py-2 rounded-full flex items-center">
-              <i class="fa-solid fa-arrow-right-to-bracket mr-2"></i> Continue
-            </button>
-          </form>
+          <div class="space-y-4">
+            <a href="{% url 'teach' %}" class="block w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-4 rounded-lg transition duration-200 text-center shadow-md hover:shadow-lg">
+              <i class="fa-solid fa-chalkboard-user mr-2 text-xl"></i>
+              What do you want to teach?
+            </a>
+            
+            <a href="{% url 'learn' %}" class="block w-full bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-4 rounded-lg transition duration-200 text-center shadow-md hover:shadow-lg">
+              <i class="fa-solid fa-graduation-cap mr-2 text-xl"></i>
+              What do you want to learn?
+            </a>
+          </div>
         </div>
         <!-- Progress Trackers Dashboard -->
         {% if user.is_authenticated %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -392,9 +392,9 @@
                       <span class="text-gray-600 dark:text-gray-400">{{ tracker.percentage }}%</span>
                     </div>
                     <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
-                      <!-- <div class="bg-{{ tracker.color }} h-3 rounded-full"
-                        style="width: {{ tracker.percentage|float }}%;">
-                      </div>                  -->
+                      <div class="bg-{{ tracker.color }} h-3 rounded-full"
+                        style="width: {{ tracker.percentage }}%">
+                      </div>
                     </div>
                   </div>
                 {% endfor %}


### PR DESCRIPTION
feat(ui): replace "Teach a Course" card with separate Teach and Learn buttons

Description:
This PR replaces the existing "Teach a Course" card with two separate buttons:

"What do you want to teach?" → Navigates to /teach
"What do you want to learn?" → Navigates to /learn
This improves user clarity by explicitly distinguishing between teaching and learning paths.

![{27F49A6E-A4EF-4A07-A3AC-F766AA9680C6}](https://github.com/user-attachments/assets/94e280dd-2b66-40a4-a7d7-296e73830864)
