### PR TITLE
Feature: Allow Teachers to Award Achievements to Students Directly #191

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -10,6 +10,8 @@ from django.utils.crypto import get_random_string
 from django.utils.text import slugify
 from markdownx.fields import MarkdownxFormField
 
+
+
 from .models import (
     BlogPost,
     ChallengeSubmission,
@@ -37,6 +39,7 @@ from .models import (
     SuccessStory,
     TeamGoal,
     TeamInvite,
+    Achievement,
 )
 from .referrals import handle_referral
 from .widgets import (
@@ -240,7 +243,63 @@ class UserRegistrationForm(SignupForm):
             handle_referral(user, referral_code)
 
         return user
+# start Award achievement..............
 
+class AwardAchievementForm(forms.Form):
+    student = forms.ModelChoiceField(
+        queryset=User.objects.none(),
+        empty_label="Select a student",
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    
+    achievement_type = forms.ChoiceField(
+        choices=Achievement.TYPES,
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    
+    course = forms.ModelChoiceField(
+        queryset=Course.objects.all(),
+        empty_label="Select a course (optional)",
+        required=False,
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    
+    title = forms.CharField(
+        max_length=100,
+        widget=forms.TextInput(attrs={'class': 'form-control'})
+    )
+    
+    description = forms.CharField(
+        widget=forms.Textarea(attrs={'class': 'form-control', 'rows': 3}),
+        required=False
+    )
+    
+    badge_icon = forms.ChoiceField(
+        choices=[(
+            'fas fa-trophy', 'Trophy'),
+            ('fas fa-medal', 'Medal'),
+            ('fas fa-award', 'Award'),
+            ('fas fa-star', 'Star'),
+            ('fas fa-certificate', 'Certificate'),
+            ('fas fa-graduation-cap', 'Graduation Cap')
+        ],
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    
+    def __init__(self, *args, **kwargs):
+        teacher = kwargs.pop('teacher', None)
+        super().__init__(*args, **kwargs)
+        
+        # If teacher is provided, filter students to only those in the teacher's courses
+        if teacher:
+            teacher_courses = Course.objects.filter(teacher=teacher)
+            student_ids = []
+            for course in teacher_courses:
+                student_ids.extend(course.students.values_list('id', flat=True))
+            
+            self.fields['student'].queryset = User.objects.filter(id__in=student_ids)
+            self.fields['course'].queryset = teacher_courses
+# end award achievement..................
 
 class ProfileForm(forms.ModelForm):
     class Meta:

--- a/web/templates/award_achievement.html
+++ b/web/templates/award_achievement.html
@@ -1,0 +1,108 @@
+<!-- web/templates/award_achievement.html -->
+{% extends "base.html" %}
+
+{% block title %}Award Achievement{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card shadow">
+                <div class="card-header bg-primary text-white">
+                    <h4 class="card-title mb-0">Award Achievement to Student</h4>
+                </div>
+                <div class="card-body">
+                    <form method="post">
+                        {% csrf_token %}
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.student.id_for_label }}" class="form-label">Student</label>
+                            {{ form.student }}
+                            {% if form.student.errors %}
+                                <div class="text-danger mt-1">{{ form.student.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.achievement_type.id_for_label }}" class="form-label">Achievement Type</label>
+                            {{ form.achievement_type }}
+                            {% if form.achievement_type.errors %}
+                                <div class="text-danger mt-1">{{ form.achievement_type.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.course.id_for_label }}" class="form-label">Course (Optional)</label>
+                            {{ form.course }}
+                            {% if form.course.errors %}
+                                <div class="text-danger mt-1">{{ form.course.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.title.id_for_label }}" class="form-label">Achievement Title</label>
+                            {{ form.title }}
+                            {% if form.title.errors %}
+                                <div class="text-danger mt-1">{{ form.title.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.description.id_for_label }}" class="form-label">Description (Optional)</label>
+                            {{ form.description }}
+                            {% if form.description.errors %}
+                                <div class="text-danger mt-1">{{ form.description.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.badge_icon.id_for_label }}" class="form-label">Badge Icon</label>
+                            <div class="d-flex align-items-center">
+                                {{ form.badge_icon }}
+                                <div class="ms-3 badge-preview">
+                                    <i id="icon-preview" class="fas fa-trophy fa-2x"></i>
+                                </div>
+                            </div>
+                            {% if form.badge_icon.errors %}
+                                <div class="text-danger mt-1">{{ form.badge_icon.errors }}</div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                            <a href="{% url 'teacher_dashboard' %}" class="btn btn-secondary">Cancel</a>
+                            <button type="submit" class="btn btn-primary">Award Achievement</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const badgeIconSelect = document.getElementById('{{ form.badge_icon.id_for_label }}');
+    const iconPreview = document.getElementById('icon-preview');
+    
+    badgeIconSelect.addEventListener('change', function() {
+        iconPreview.className = badgeIconSelect.value + ' fa-2x';
+    });
+});
+// Add this to a JavaScript file or inline in the template
+function initBadgePreview() {
+    const badgeIconSelect = document.getElementById('id_badge_icon');
+    const iconPreview = document.getElementById('icon-preview');
+    
+    if (badgeIconSelect && iconPreview) {
+        badgeIconSelect.addEventListener('change', function() {
+            iconPreview.className = badgeIconSelect.value + ' fa-2x';
+        });
+        
+        // Initialize with the current value
+        iconPreview.className = badgeIconSelect.value + ' fa-2x';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', initBadgePreview);
+</script>
+{% endblock %}

--- a/web/templates/dashboard/teacher.html
+++ b/web/templates/dashboard/teacher.html
@@ -38,6 +38,12 @@
           </div>
         </div>
       </div>
+        <!-- AWARD ACHIEVEMENTS -->
+  <!-- Add this button to the teacher dashboard template -->
+<a href="{% url 'award_achievement' %}" class="btn btn-primary mb-3">
+  <i class="fas fa-award me-2"></i>Award Achievement
+</a> 
+         <!-- AWARD ACHIEVEMENTS -->
       <!-- Total Earnings -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
         <div class="flex items-center justify-between">
@@ -144,6 +150,7 @@
           </div>
         </div>
       </div>
+    
       <!-- Upcoming Sessions -->
       <div>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow">

--- a/web/urls.py
+++ b/web/urls.py
@@ -6,6 +6,8 @@ from django.contrib.auth.decorators import login_required
 from django.urls import include, path
 
 from . import admin_views, peer_challenge_views, quiz_views, views
+from web import views
+
 from .views import (
     GoodsListingView,
     GradeableLinkCreateView,
@@ -23,6 +25,8 @@ from .views import (
 urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),  # Language selection URLs
     path("captcha/", include("captcha.urls")),  # CAPTCHA URLs should not be language-prefixed
+
+
 ]
 
 if settings.DEBUG:
@@ -233,6 +237,7 @@ urlpatterns += i18n_patterns(
         name="store_order_management",
     ),
     path("orders/item/<int:item_id>/update-status/", views.update_order_status, name="update_order_status"),
+    path('award-achievement/', views.award_achievement, name='award_achievement'),
     # Analytics
     path(
         "store/<slug:store_slug>/analytics/",

--- a/web/views.py
+++ b/web/views.py
@@ -82,6 +82,7 @@ from .forms import (
     TeamGoalForm,
     TeamInviteForm,
     UserRegistrationForm,
+    AwardAchievementForm,
 )
 from .marketing import (
     generate_social_share_content,
@@ -1001,7 +1002,51 @@ def mark_session_completed(request, session_id):
 
     messages.success(request, "Session marked as completed!")
     return redirect("course_detail", slug=session.course.slug)
+# start award achievement
 
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from web.forms import AwardAchievementForm
+from web.models import Achievement, Profile
+
+@login_required
+def award_achievement(request):
+    # Check if user is a teacher
+    try:
+        profile = request.user.profile
+        if not profile.is_teacher:
+            messages.error(request, 'You do not have permission to award achievements.')
+            return redirect('dashboard')
+    except Profile.DoesNotExist:
+        messages.error(request, 'Profile not found.')
+        return redirect('dashboard')
+    
+    if request.method == 'POST':
+        form = AwardAchievementForm(request.POST, teacher=request.user)
+        if form.is_valid():
+            # Create the achievement
+            achievement = Achievement.objects.create(
+                student=form.cleaned_data['student'],
+                course=form.cleaned_data['course'],
+                achievement_type=form.cleaned_data['achievement_type'],
+                title=form.cleaned_data['title'],
+                description=form.cleaned_data['description'],
+                badge_icon=form.cleaned_data['badge_icon']
+            )
+            
+            messages.success(
+                request, 
+                f'Achievement "{form.cleaned_data["title"]}" awarded to {form.cleaned_data["student"].username}'
+            )
+            return redirect('teacher_dashboard')
+    else:
+        form = AwardAchievementForm(teacher=request.user)
+    
+    return render(request, 'award_achievement.html', {'form': form})
+
+
+# end award achievement
 
 @login_required
 def student_progress(request, enrollment_id):


### PR DESCRIPTION
Feature: Allow Teachers to Award Achievements (#191)
This PR implements the ability for teachers to award achievements to students directly from the teacher dashboard.

**Added:**
AwardAchievementForm to collect achievement info
award_achievement view with teacher check
URL route /award-achievement/
Template with badge icon preview
Button in teacher_dashboard.html

**Note:**
I completed the implementation as described, but I’m unable to log in as a teacher to test it.
Tried setting is_teacher, is_staff, verified email, and used changepassword, but /dashboard/teacher/ keeps redirecting to login and /award-achievement/ gives 404.

Would appreciate guidance to test fully.