### PR TITLE
Add Top Contributors Section and Contributor Details View

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -801,6 +801,156 @@
             </a>
           </div>
         </div>
+        <!-- Top 3 Contributors of the Month -->
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4 mt-6">
+          <h2 class="text-lg font-semibold mb-4 flex items-center">
+            <i class="fa-solid fa-award text-blue-600 dark:text-blue-400 mr-2"></i>
+            Top 3 Contributors of the Month
+          </h2>
+          <div id="top-contributors-section" class="space-y-4">
+            <!-- Loading placeholders -->
+            <div class="animate-pulse space-y-3">
+              <div class="flex items-center space-x-3">
+                <div class="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
+                <div class="flex-1">
+                  <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+                </div>
+              </div>
+              <div class="flex items-center space-x-3">
+                <div class="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
+                <div class="flex-1">
+                  <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+                </div>
+              </div>
+              <div class="flex items-center space-x-3">
+                <div class="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
+                <div class="flex-1">
+                  <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <script>
+            async function fetchTopContributors() {
+                const today = new Date();
+                const currentYear = today.getFullYear();
+                const currentMonth = today.getMonth();
+                const startOfMonth = new Date(currentYear, currentMonth, 1);
+                const endOfMonth = new Date(currentYear, currentMonth + 1, 0, 23, 59, 59);
+                const container = document.getElementById('top-contributors-section');
+
+                async function fetchAllMergedPRs() {
+                    let page = 1;
+                    let allPulls = [];
+                    while (true) {
+                        const response = await fetch(
+                            `https://api.github.com/repos/AlphaOneLabs/education-website/pulls?state=closed&per_page=100&page=${page}`
+                        );
+                        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                        const pulls = await response.json();
+                        allPulls = allPulls.concat(pulls);
+                        if (pulls.length < 100) break;
+                        page++;
+                    }
+                    return allPulls;
+                }
+
+                try {
+                    const pulls = await fetchAllMergedPRs();
+                    const contributors = {};
+
+                    // Process each pull request with detailed fetch
+                    for (const pull of pulls) {
+                        if (!pull.merged_at) continue;
+                        const mergedAt = new Date(pull.merged_at);
+                        if (mergedAt < startOfMonth || mergedAt > endOfMonth) continue;
+                        const username = pull.user.login;
+                        if (username.includes('[bot]') || username.includes('dependabot') || username === 'A1L13N') continue;
+
+                        // Fetch detailed PR information to get additions
+                        let additions = 0;
+                        try {
+                            const prDetailResponse = await fetch(pull.url);
+                            if (!prDetailResponse.ok) continue;
+                            const prDetail = await prDetailResponse.json();
+                            additions = prDetail.additions || 0;
+                        } catch (error) {
+                            console.error(`Error fetching PR details for #${pull.number}:`, error);
+                            continue;
+                        }
+
+                        // Update contributor stats
+                        if (!contributors[username]) {
+                            contributors[username] = {
+                                username,
+                                avatar_url: pull.user.avatar_url,
+                                profile_url: pull.user.html_url,
+                                pr_count: 0,
+                                lines_added: 0,
+                            };
+                        }
+                        contributors[username].pr_count++;
+                        contributors[username].lines_added += additions;
+                    }
+
+                    // Rest of the code remains the same...
+                    if (Object.keys(contributors).length === 0) {
+                        container.innerHTML = `<p class="text-sm text-gray-600 dark:text-gray-400 text-center py-4">No contributors found for this month.</p>`;
+                        return;
+                    }
+
+                    const contributorList = Object.values(contributors);
+                    const maxPRCount = Math.max(...contributorList.map(c => c.pr_count));
+                    const maxLinesAdded = Math.max(...contributorList.map(c => c.lines_added));
+                    const rankedContributors = contributorList
+                        .map(contributor => {
+                            const normalizedPR = maxPRCount > 0 ? contributor.pr_count / maxPRCount : 0;
+                            const normalizedLines = maxLinesAdded > 0 ? contributor.lines_added / maxLinesAdded : 0;
+                            return {
+                                ...contributor,
+                                weighted_score: 0.5 * normalizedPR + 0.5 * normalizedLines,
+                            };
+                        })
+                        .sort((a, b) => b.weighted_score - a.weighted_score)
+                        .slice(0, 3);
+
+                    container.innerHTML = '';
+                    rankedContributors.forEach((contributor, index) => {
+                        const div = document.createElement('div');
+                        div.className = 'flex items-center space-x-3 p-2 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors duration-200';
+                        let rankBadge = index === 0 ? '🥇' : index === 1 ? '🥈' : '🥉';
+                        div.innerHTML = `
+        <div class="relative">
+          <img src="${contributor.avatar_url}" alt="${contributor.username}" class="w-10 h-10 rounded-full" loading="lazy" width="40" height="40" />
+          <div class="absolute -bottom-1 -left-1 w-5 h-5 bg-yellow-500 text-white text-xs font-bold flex items-center justify-center rounded-full border-2 border-white dark:border-gray-800">
+            ${rankBadge}
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <a href="${contributor.profile_url}" target="_blank" class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-orange-500 dark:hover:text-orange-400">
+            ${contributor.username}
+          </a>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            <span><i class="fas fa-code-branch mr-1"></i>${contributor.pr_count} PRs</span>
+            <span class="ml-3"><i class="fas fa-plus-circle mr-1"></i>${contributor.lines_added} lines added</span>
+          </div>
+        </div>
+      `;
+                        container.appendChild(div);
+                    });
+                } catch (error) {
+                    container.innerHTML = `
+      <p class="text-sm text-gray-600 dark:text-gray-400 text-center py-4">
+        <i class="fas fa-exclamation-circle text-red-500 mr-2"></i>
+        Failed to load top 3 contributors. Please try again later.
+      </p>
+    `;
+                    console.error('Error fetching top contributors:', error);
+                }
+            }
+            document.addEventListener('DOMContentLoaded', fetchTopContributors);
+        </script>
       </div>
     </div>
     <!-- GitHub Contributors Section -->

--- a/web/templates/web/all_contributors.html
+++ b/web/templates/web/all_contributors.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="w-full max-w-7xl mx-auto mt-6 px-4 md:px-6">
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-2 flex items-center">
+      <span class="mr-2">🏆</span>Top Contributors
+    </h1>
+    <p class="text-gray-600 dark:text-gray-300 mb-6">
+      Recognizing our most active contributors based on merged pull requests.
+    </p>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+      {% if contributors %}
+        <table class="w-full text-left border-collapse">
+          <thead>
+            <tr class="bg-teal-600 text-white">
+              <!-- Updated to match the green theme -->
+              <th class="px-4 py-3">Rank</th>
+              <th class="px-4 py-3">Contributor</th>
+              <th class="px-4 py-3">Merged PRs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for contributor in contributors %}
+              <tr class="border-t border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition">
+                <td class="px-4 py-3">
+                  {% if forloop.counter == 1 %}
+                    🥇
+                  {% elif forloop.counter == 2 %}
+                    🥈
+                  {% elif forloop.counter == 3 %}
+                    🥉
+                  {% else %}
+                    {{ forloop.counter }}
+                  {% endif %}
+                </td>
+                <td class="px-4 py-3 flex items-center space-x-3">
+                  <img src="{{ contributor.avatar_url }}"
+                       alt="{{ contributor.login }}"
+                       class="h-10 w-10 rounded-full" />
+                  <a href="{% url 'contributor_detail' contributor.login %}"
+                     class="text-blue-600 hover:underline dark:text-blue-400">{{ contributor.login }}</a>
+                </td>
+                <td class="px-4 py-3">{{ contributor.merged_prs|default:"0" }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="text-center text-gray-600 dark:text-gray-300 py-6">No contributors found.</p>
+      {% endif %}
+    </div>
+  </main>
+{% endblock content %}

--- a/web/templates/web/contributor_detail.html
+++ b/web/templates/web/contributor_detail.html
@@ -1,0 +1,417 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="w-full max-w-7xl mx-auto mt-6 px-4 md:px-6">
+    <!-- Title Section -->
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-6">Contributor Details: {{ user.login }}</h1>
+    <!-- Main Grid: Basic Info & Engagement Metrics -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <!-- Basic Info Card -->
+      <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 transition-all hover:shadow-xl">
+        <div class="flex items-center space-x-4">
+          <img src="{{ user.avatar_url }}"
+               alt="{{ user.login }}"
+               class="h-16 w-16 rounded-full border-4 border-blue-100 dark:border-gray-600" />
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">{{ user.name|default:user.login }}</h2>
+            <p class="text-gray-600 dark:text-gray-300 mt-1">{{ user.bio|default:"No bio available" }}</p>
+            <a href="{{ user.html_url }}"
+               target="_blank"
+               class="inline-flex items-center mt-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
+              <span>GitHub Profile</span>
+              <svg class="w-4 h-4 ml-1"
+                   fill="none"
+                   stroke="currentColor"
+                   viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4 M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+      <!-- Engagement Metrics Grid -->
+      <div class="grid grid-cols-2 gap-4">
+        <div class="bg-blue-100 dark:bg-blue-900 p-4 rounded-xl flex items-center transition hover:shadow-lg">
+          <div class="flex-1">
+            <p class="text-sm text-blue-800 dark:text-blue-200">Reactions</p>
+            <p class="text-2xl font-bold text-blue-600 dark:text-blue-300">{{ user.reactions_received|default:"0" }}</p>
+          </div>
+          <div class="w-12 h-12 bg-blue-600 dark:bg-blue-700 rounded-full flex items-center justify-center">⭐</div>
+        </div>
+        <div class="bg-purple-100 dark:bg-purple-900 p-4 rounded-xl flex items-center transition hover:shadow-lg">
+          <div class="flex-1">
+            <p class="text-sm text-purple-800 dark:text-purple-200">Followers</p>
+            <p class="text-2xl font-bold text-purple-600 dark:text-purple-300">{{ user.followers|default:"0" }}</p>
+          </div>
+          <div class="w-12 h-12 bg-purple-600 dark:bg-purple-700 rounded-full flex items-center justify-center">👥</div>
+        </div>
+        <div class="bg-green-100 dark:bg-green-900 p-4 rounded-xl flex items-center transition hover:shadow-lg">
+          <div class="flex-1">
+            <p class="text-sm text-green-800 dark:text-green-200">Mentorship</p>
+            <p class="text-2xl font-bold text-green-600 dark:text-green-300">{{ user.mentorship_score|default:"0" }}</p>
+          </div>
+          <div class="w-12 h-12 bg-green-600 dark:bg-green-700 rounded-full flex items-center justify-center">🤝</div>
+        </div>
+        <div class="bg-orange-100 dark:bg-orange-900 p-4 rounded-xl flex items-center transition hover:shadow-lg">
+          <div class="flex-1">
+            <p class="text-sm text-orange-800 dark:text-orange-200">Collaboration</p>
+            <p class="text-2xl font-bold text-orange-600 dark:text-orange-300">{{ user.collaboration_score|default:"0" }}</p>
+          </div>
+          <div class="w-12 h-12 bg-orange-600 dark:bg-orange-700 rounded-full flex items-center justify-center">🔗</div>
+        </div>
+      </div>
+    </div>
+    <!-- Contributor Statistics -->
+    <div class="mt-8">
+      <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Contribution Analytics</h3>
+      <!-- Responsive chart grid -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <!-- Pull Requests: Pie Chart -->
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 md:col-span-2">
+          <h4 class="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">Pull Requests</h4>
+          <div class="relative h-64">
+            <canvas id="pullRequestsChart"></canvas>
+          </div>
+        </div>
+        <!-- Issues: Bar Chart -->
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4">
+          <h4 class="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">Issues</h4>
+          <div class="relative h-64">
+            <canvas id="issuesChart"></canvas>
+          </div>
+        </div>
+        <!-- Comments: Line Chart -->
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4">
+          <h4 class="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">Comments</h4>
+          <div class="relative h-64">
+            <canvas id="commentsChart"></canvas>
+          </div>
+        </div>
+        <!-- Code Contributions: Horizontal Bar Chart -->
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 md:col-span-2">
+          <h4 class="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">Code Contributions</h4>
+          <div class="relative h-64">
+            <canvas id="codeContributionsChart"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Recent Activity Timeline -->
+    <div class="mt-8 bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6">
+      <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">Recent Activity</h3>
+      <div class="flow-root">
+        <ul class="-mb-8">
+          <!-- First Contribution -->
+          <li class="relative pb-8">
+            <div class="relative flex items-start space-x-3">
+              <div class="relative px-1">
+                <div class="h-8 w-8 bg-blue-500 rounded-full flex items-center justify-center text-white">📅</div>
+              </div>
+              <div class="min-w-0 flex-1 py-0">
+                <div class="text-sm text-gray-600 dark:text-gray-300">
+                  <p>
+                    First contribution on
+                    <span class="font-medium">{{ first_contribution_date|default:"N/A" }}</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+          <!-- Issue Assignments -->
+          <li class="relative pb-8">
+            <div class="relative flex items-start space-x-3">
+              <div class="relative px-1">
+                <div class="h-8 w-8 bg-green-500 rounded-full flex items-center justify-center text-white">✅</div>
+              </div>
+              <div class="min-w-0 flex-1 py-0">
+                <div class="text-sm text-gray-600 dark:text-gray-300">
+                  <p>
+                    Completed
+                    <span class="font-medium">{{ user.issue_assignments|default:"0" }}</span>
+                    issue assignments
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+          <!-- More activity items can be added here -->
+        </ul>
+      </div>
+    </div>
+  </main>
+  <!-- Chart.js & Plugins -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
+  <script>
+      // Ensure values are numbers (Django template will output raw numbers)
+      const prsCreated = {
+          {
+              prs_created |
+                  default: "0"
+          }
+      };
+      const prsMerged = {
+          {
+              prs_merged |
+                  default: "0"
+          }
+      };
+      const prReviews = {
+          {
+              pr_reviews |
+                  default: "0"
+          }
+      };
+      const issuesCreated = {
+          {
+              issues_created |
+                  default: "0"
+          }
+      };
+      const issueAssignments = {
+          {
+              user.issue_assignments |
+                  default: "0"
+          }
+      };
+      const prComments = {
+          {
+              pr_comments |
+                  default: "0"
+          }
+      };
+      const issueComments = {
+          {
+              issue_comments |
+                  default: "0"
+          }
+      };
+      const linesAdded = {
+          {
+              lines_added |
+                  default: "0"
+          }
+      };
+      const linesDeleted = {
+          {
+              lines_deleted |
+                  default: "0"
+          }
+      };
+
+      // Register the data labels plugin globally
+      Chart.register(ChartDataLabels);
+
+      // Common chart options for light mode
+      const chartOptions = {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+              legend: {
+                  position: 'top',
+                  labels: {
+                      color: '#6B7280'
+                  }
+              },
+              datalabels: {
+                  color: '#6B7280',
+                  anchor: 'end',
+                  align: 'end'
+              }
+          },
+          scales: {
+              x: {
+                  grid: {
+                      color: '#E5E7EB'
+                  },
+                  ticks: {
+                      color: '#6B7280',
+                      beginAtZero: true
+                  }
+              },
+              y: {
+                  grid: {
+                      color: '#E5E7EB'
+                  },
+                  ticks: {
+                      color: '#6B7280',
+                      beginAtZero: true
+                  }
+              }
+          }
+      };
+
+      // Function to apply dark mode options to a chart instance
+      function applyDarkMode(chart) {
+          chart.options.plugins.legend.labels.color = '#D1D5DB';
+          chart.options.plugins.datalabels.color = '#D1D5DB';
+          chart.options.scales.x.grid.color = '#374151';
+          chart.options.scales.x.ticks.color = '#D1D5DB';
+          chart.options.scales.y.grid.color = '#374151';
+          chart.options.scales.y.ticks.color = '#D1D5DB';
+          chart.update();
+      }
+
+      // Create Pull Requests chart as a pie chart
+      const prCtx = document.getElementById('pullRequestsChart').getContext('2d');
+      const prChart = new Chart(prCtx, {
+          type: 'pie',
+          data: {
+              labels: ['Created', 'Merged', 'Reviewed'],
+              datasets: [{
+                  data: [prsCreated, prsMerged, prReviews],
+                  backgroundColor: ['#3B82F6', '#10B981', '#F59E0B']
+              }]
+          },
+          options: {
+              responsive: true,
+              plugins: {
+                  legend: {
+                      position: 'top',
+                      labels: {
+                          color: '#6B7280'
+                      }
+                  }
+              }
+          }
+      });
+
+      // Create Issues chart as a bar chart
+      const issuesCtx = document.getElementById('issuesChart').getContext('2d');
+      const issuesChart = new Chart(issuesCtx, {
+          type: 'bar',
+          data: {
+              labels: ['Created', 'Completed'],
+              datasets: [{
+                  label: 'Issues',
+                  data: [issuesCreated, issueAssignments],
+                  backgroundColor: ['#EF4444', '#10B981']
+              }]
+          },
+          options: {
+              responsive: true,
+              plugins: {
+                  legend: {
+                      display: false
+                  }
+              },
+              scales: {
+                  x: {
+                      grid: {
+                          color: '#E5E7EB'
+                      },
+                      ticks: {
+                          color: '#6B7280'
+                      }
+                  },
+                  y: {
+                      beginAtZero: true,
+                      grid: {
+                          color: '#E5E7EB'
+                      },
+                      ticks: {
+                          color: '#6B7280'
+                      }
+                  }
+              }
+          }
+      });
+
+      // Create Comments chart as a line chart
+      const commentsCtx = document.getElementById('commentsChart').getContext('2d');
+      const commentsChart = new Chart(commentsCtx, {
+          type: 'line',
+          data: {
+              labels: ['PR Comments', 'Issue Comments'],
+              datasets: [{
+                  label: 'Comments',
+                  data: [prComments, issueComments],
+                  borderColor: '#8B5CF6',
+                  backgroundColor: 'rgba(139, 92, 246, 0.2)',
+                  fill: true
+              }]
+          },
+          options: chartOptions
+      });
+
+      // Create Code Contributions chart as a horizontal bar (stacked) chart
+      const locCtx = document.getElementById('codeContributionsChart').getContext('2d');
+      const locChart = new Chart(locCtx, {
+          type: 'bar',
+          data: {
+              labels: ['Contributions'],
+              datasets: [{
+                  label: 'Lines Added',
+                  data: [linesAdded],
+                  backgroundColor: '#10B981'
+              }, {
+                  label: 'Lines Deleted',
+                  data: [linesDeleted],
+                  backgroundColor: '#EF4444'
+              }]
+          },
+          options: {
+              responsive: true,
+              indexAxis: 'y',
+              plugins: {
+                  legend: {
+                      position: 'top'
+                  }
+              },
+              scales: {
+                  x: {
+                      stacked: true,
+                      grid: {
+                          color: '#E5E7EB'
+                      },
+                      ticks: {
+                          color: '#6B7280',
+                          beginAtZero: true
+                      }
+                  },
+                  y: {
+                      stacked: true,
+                      grid: {
+                          color: '#E5E7EB'
+                      },
+                      ticks: {
+                          color: '#6B7280'
+                      }
+                  }
+              }
+          }
+      });
+
+      // Collect chart instances for dark mode handling
+      const chartInstances = [prChart, issuesChart, commentsChart, locChart];
+
+      // Dark mode media query
+      const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      // Apply dark mode if enabled initially
+      if (darkModeQuery.matches) {
+          chartInstances.forEach(chart => applyDarkMode(chart));
+      }
+
+      // Listen for changes in dark mode preference
+      darkModeQuery.addEventListener('change', (e) => {
+          if (e.matches) {
+              chartInstances.forEach(chart => applyDarkMode(chart));
+          } else {
+              // For light mode, you might re-create options from scratch if needed.
+              // Here, we'll simply reload the page charts by updating options.
+              chartInstances.forEach(chart => {
+                  chart.options = structuredClone(chartOptions);
+                  chart.update();
+              });
+          }
+      });
+  </script>
+  <style>
+      /* Optional: Set a background for canvas elements in dark mode */
+      .dark canvas {
+          background-color: #1F2937;
+          border-radius: 0.75rem;
+      }
+  </style>
+{% endblock content %}

--- a/web/urls.py
+++ b/web/urls.py
@@ -107,6 +107,8 @@ urlpatterns += i18n_patterns(
     path(f"{settings.ADMIN_URL}/dashboard/", admin_views.admin_dashboard, name="admin_dashboard"),
     path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("subjects/", views.subjects, name="subjects"),
+    path("admin/all-contributors/", views.all_contributors_view, name="all_contributors"),
+    path("contributors/<str:username>/", views.contributor_detail_view, name="contributor_detail"),
     # Progress tracking URLs
     path(
         "sessions/<int:session_id>/attendance/",


### PR DESCRIPTION
This PR introduces a feature to display the top 3 contributors for the current month on the admin dashboard. It also provides detailed information about each contributor, including PRs created, merged, lines added, and other GitHub activity metrics.

## Changes:
- **Frontend (HTML/JavaScript):**
  - Added a "Top 3 Contributors of the Month" section on the main dashboard page.
  - Introduced dynamic fetching of GitHub data (PRs, contributions) using the GitHub API.
  - Displayed contributor rankings with avatars, PR counts, and lines added.
  
- **Backend (Views & URLs):**
  - Added a view to fetch all contributors' statistics using the GitHub API.
  - Implemented a detailed contributor profile page showing stats like PRs created, reviews, issue assignments, and more.
  
- **New Templates:**
  - Created templates for displaying the list of all contributors (`all_contributors.html`) and individual contributor details (`contributor_detail.html`).

## API Calls:
- The feature fetches data from the GitHub API, including:
  - Closed PRs for the current month.
  - Contributor statistics such as PR count, lines added, reviews, and more.

## Additional Notes:
- This feature only fetches data for non-bot users and excludes certain bots (e.g., `dependabot`).
- The contributor ranking is based on both PR count and lines added, with a weighted score for ranking purposes.
