### PR TITLE
Fixes the bug in the product image url

### DIFF
--- a/web/templates/goods/goods_listing.html
+++ b/web/templates/goods/goods_listing.html
@@ -71,7 +71,7 @@
           <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-4 border border-gray-200 dark:border-gray-700">
             <a href="{% url 'goods_detail' pk=product.id %}"
                class="block overflow-hidden rounded-md">
-              <img src="{% if product.image %}{{ product.image.url }}{% else %}/static/images/placeholder.png{% endif %}"
+              <img src="{% if product.image_url %}{{ product.image_url }}{% else %}/static/images/placeholder.png{% endif %}"
                    alt="{{ product.name }}"
                    class="w-full h-56 object-cover rounded-md" />
             </a>


### PR DESCRIPTION
Fixes Product Images Not Displaying #200

Fixes Images are not working for products #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the product listing page to retrieve and display product images correctly, ensuring that when an image isn’t available, a fallback placeholder is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->