### PR TITLE
fix: Restrict course listing to published courses and adjust map link placement

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -154,15 +154,16 @@
   <body class="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-black dark:text-gray-100 transition-colors duration-300 overflow-x-hidden">
     <!-- HEADER -->
     <header class="w-full bg-teal-600 dark:bg-teal-800 text-white shadow-md">
-      <div class="max-w-[90rem] mx-auto px-4 md:px-6 flex items-center justify-between h-[70px] relative">
+      <div class="max-w-[90rem] mx-auto px-4 md:px-6 flex items-center justify-between h-[70px] relative gap-2">
         <!-- Logo and Title -->
-        <a href="{% url 'index' %}" class="flex items-center space-x-2">
+        <a href="{% url 'index' %}"
+           class="flex flex-1 min-w-[150px] max-w-[50%] items-center space-x-2">
           <img src="{% static 'images/logo.png' %}"
                alt="Alpha One Labs Logo"
                height="40"
                width="40"
                class="h-10 w-10" />
-          <span class="text-xl font-bold text-white">Alpha One Labs</span>
+          <span class="text-xl font-bold text-white ">Alpha One Labs</span>
         </a>
         <!-- Mobile Menu Button -->
         <button class="md:hidden p-2 hover:bg-teal-700 rounded-lg"
@@ -170,12 +171,16 @@
           <i class="fas fa-bars text-xl"></i>
         </button>
         <!-- Nav and additional actions -->
-        <nav class="hidden md:flex items-center space-x-6">
+        <nav class="hidden md:flex items-center space-x-3">
           <!-- Main navigation links with dropdowns -->
-          <div class="flex space-x-6 items-center">
-            <a class="nav-link" href="{% url 'classes_map' %}">
-              <i class="fas fa-map-marker-alt"></i> Classes Near Me
-            </a>
+          <div class="flex space-x-2 items-center">
+            <div class="relative group ">
+              <a class="nav-link flex flex-1 min-w-[150px] max-w-[50%] items-center space-x-2"
+                 href="{% url 'classes_map' %}">
+                <i class="fas fa-map-marker-alt"></i>
+                <span>Classes Near Me</span>
+              </a>
+            </div>
             <!-- LEARN Dropdown -->
             <div class="relative group">
               <button class="flex items-center space-x-1 text-white hover:text-teal-100 focus:outline-none py-2">

--- a/web/views.py
+++ b/web/views.py
@@ -6086,7 +6086,7 @@ def map_data_api(request):
     age_group = request.GET.get("age_group")
 
     if course_id:
-        sessions = sessions.filter(course__id=course_id)
+        sessions = sessions.filter(course__id=course_id, status="published")
     if age_group:
         sessions = sessions.filter(course__level=age_group)
 

--- a/web/views.py
+++ b/web/views.py
@@ -6059,7 +6059,7 @@ def classes_map(request):
     teaching_style = request.GET.get("teaching_style")
     # Apply filters
     if course_id:
-        sessions = sessions.filter(course_id=course_id)
+        sessions = sessions.filter(course_id=course_id, status="published")
     if teaching_style:
         sessions = sessions.filter(teaching_style=teaching_style)
     # Fetch only necessary course fields


### PR DESCRIPTION
I made changes in web/templates/base.html within the <div> where 'Classes Near Me' is located, adjusting its style for a responsive view. Additionally, I modified web/views.py at line 6062 and 6089 to filter and display only published courses, excluding archived or draft courses.
Fixes  <alphaonelabs/alphaonelabs-education-website/issue#349>
Fixes #349 