### PR TITLE
Fixes #450: light mode ui/ux on signup page

### DIFF
--- a/web/templates/account/signup.html
+++ b/web/templates/account/signup.html
@@ -8,23 +8,17 @@
       .auth-container {
           max-width: 800px;
           margin: 1.5rem auto;
-          padding: 1.5rem;
+          padding: 2rem;
           background: white;
           border-radius: 0.5rem;
           box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-      }
-
-      @media (prefers-color-scheme: dark) {
-          .auth-container {
-              background-color: #1f2937;
-          }
       }
   </style>
   <!-- Add password toggle script -->
   <script src="{% static 'js/password-toggle.js' %}"></script>
 {% endblock extra_head %}
 {% block content %}
-  <div class="grid md:grid-cols-5 gap-4 items-center">
+  <div class="grid bg-white dark:bg-[#1f2937] md:grid-cols-5 gap-10 items-center">
     <!-- Left side illustration -->
     <div class="md:col-span-2 text-center hidden md:block">
       <div class="flex flex-col items-center space-y-3">


### PR DESCRIPTION
closes issue: #450

This PR resolves an issue where the colors of the light mode version of the signup page were inconsistent, affecting readability and user experience. 

### Previous:
![screencapture-alphaonelabs-en-accounts-signup-2025-04-05-14_14_43](https://github.com/user-attachments/assets/85538c02-06b4-4bf3-99e9-f0125ce976fb)

### After changing:

**For light mode**:
![screencapture-localhost-8000-en-accounts-signup-2025-04-05-15_08_37](https://github.com/user-attachments/assets/0f718023-eab4-4c77-b829-86e3f0dafb3a)

**For dark mode**:
![screencapture-localhost-8000-en-accounts-signup-2025-04-05-15_08_28](https://github.com/user-attachments/assets/2f4fba80-406c-4e8d-be19-ade740a54bab)
