### PR TITLE
Making Users Email Verified by default while creating test data

### DIFF
--- a/web/management/commands/create_test_data.py
+++ b/web/management/commands/create_test_data.py
@@ -2,6 +2,7 @@ import random
 from datetime import timedelta
 from decimal import Decimal
 
+from allauth.account.models import EmailAddress
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -95,6 +96,7 @@ class Command(BaseCommand):
                 last_login=timezone.now(),
             )
             Profile.objects.filter(user=user).update(is_teacher=True)
+            EmailAddress.objects.create(user=user, email=user.email, primary=True, verified=True)
             teachers.append(user)
             self.stdout.write(f"Created teacher: {user.username}")
 
@@ -108,6 +110,7 @@ class Command(BaseCommand):
                 last_name="Doe",
                 last_login=timezone.now(),
             )
+            EmailAddress.objects.create(user=user, email=user.email, primary=True, verified=True)
             students.append(user)
             self.stdout.write(f"Created student: {user.username}")
 


### PR DESCRIPTION
**Summary:** 
This PR enhances the [create_test_data.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) script by adding logic to automatically mark email addresses as verified for demo users (teachers and students) during test data creation. This ensures that all generated users have verified email addresses by default, streamlining the testing process and avoiding manual email verification steps.

**Issue Addressed** : #416 

**Changes Made:**

- Updated the [create_test_data.py]script to:
  - Create an EmailAddress entry for each user using the django-allauth model.
  - Set the verified field to True and primary to True for all demo users' email addresses.
  - Ensured that both teachers and students created during test data generation have verified email addresses.
     
**Benefits:**

Simplifies testing workflows by eliminating the need for manual email verification.
Ensures compatibility with features that require email verification, such as login and notifications.
Improves the efficiency of testing processes by providing ready-to-use demo users.

**Testing:**

Verified that all demo users created by the script have their email addresses marked as verified.
Confirmed that the EmailAddress entries are correctly associated with the respective users.