### PR TITLE
fix(base): invert logo color in dark mode.

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -952,7 +952,7 @@
                  class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                 <img src="{% static 'images/x-logo.svg' %}"
                      alt="X (Twitter) Logo"
-                     class="w-5 h-5"
+                     class="w-5 h-5 dark:invert"
                      width="20"
                      height="20" />
               </a>


### PR DESCRIPTION
closes: #490 

| Before | After |
|-------|--------|
| ![Screenshot from 2025-04-07 21-49-01](https://github.com/user-attachments/assets/931f3943-5595-40df-9609-1bc5164c508d) |![Screenshot from 2025-04-07 21-48-20](https://github.com/user-attachments/assets/303f7f1a-1bdc-406e-9c6f-314d45f8b887) |




