### PR TITLE
Free courses cart issue

### DIFF
--- a/web/templates/cart/cart.html
+++ b/web/templates/cart/cart.html
@@ -391,3 +391,39 @@
     </script>
   {% endif %}
 {% endblock extra_js %}
+
+
+<div>
+  Total: <span id="cart-total" data-value="{{ cart.total }}">₹{{ cart.total }}</span>
+</div>
+<form id="checkout-form" method="POST" action="{% url 'checkout' %}">
+  {% csrf_token %}
+  <!-- Other form fields -->
+</form>
+{% block scripts %}
+<script>
+document.getElementById("checkout-form").addEventListener("submit", async function (e) {
+    const totalEl = document.getElementById("cart-total");
+    const total = parseFloat(totalEl.dataset.value);
+
+    if (total === 0) {
+        e.preventDefault();
+
+        const response = await fetch("{% url 'free_checkout' %}", {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+                "Content-Type": "application/json"
+            }
+        });
+
+        const result = await response.json();
+        if (result.status === "success") {
+            window.location.href = "{% url 'checkout_success' %}";
+        } else {
+            alert("Error: " + result.error);
+        }
+    }
+});
+</script>
+{% endblock %}

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -649,3 +649,13 @@ class CourseDetailTests(TestCase):
         response = self.client.get(reverse("course_detail", args=[course.slug]))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, reverse("update_course", args=[course.slug]))
+
+
+# Test to verify that free checkout works correctly via the new view
+def test_free_checkout_flow(self):
+    cart = Cart.objects.create(user=self.user)
+    CartItem.objects.create(cart=cart, goods=self.free_course, price=0)
+
+    response = self.client.post(reverse("free_checkout"))
+    self.assertEqual(response.status_code, 200)
+    self.assertIn("success", response.json()["status"])

--- a/web/urls.py
+++ b/web/urls.py
@@ -454,3 +454,10 @@ urlpatterns += i18n_patterns(
 
 handler404 = "web.views.custom_404"
 handler429 = "web.views.custom_429"
+
+#Registered the free_checkout URL Route to trigger the new view
+from . import views
+
+urlpatterns += [
+    path("cart/checkout/free/", views.free_checkout, name="free_checkout"),
+]

--- a/web/views.py
+++ b/web/views.py
@@ -7103,3 +7103,26 @@ def users_list(request: HttpRequest) -> HttpResponse:
     }
 
     return render(request, "users_list.html", context)
+
+#Function free_checkout to handle enrollments without payment
+from django.views.decorators.http import require_POST
+from django.http import JsonResponse
+from .models import Cart, Enrollment
+
+@require_POST
+def free_checkout(request):
+    try:
+        cart = Cart.objects.get(user=request.user)
+        if cart.total_amount() > 0:
+            return JsonResponse({"error": "Cart is not free"}, status=400)
+
+        for item in cart.items.all():
+            Enrollment.objects.get_or_create(
+                user=request.user,
+                course=item.course  # Adjust field name as necessary
+            )
+
+        cart.items.all().delete()  # Clear the cart
+        return JsonResponse({"status": "success"})
+    except Exception as e:
+        return JsonResponse({"error": str(e)}, status=500)


### PR DESCRIPTION
feat(views): Add free_checkout view to enroll users directly for free items.
feat(urls): Add route for free_checkout view.
feat(cart.html):
Display cart total with id="cart-total" and data-value.
Inject CSRF token in form.
Add JS logic to handle free cart submissions via AJAX.
test(checkout): Add test case for free checkout flow in test_views.py.

Fixes #485 
