### PR TITLE
[Fix]: Add dark mode support for TailwindURLInput widget

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -287,7 +287,7 @@ class UserRegistrationForm(SignupForm):
 class TailwindInput(forms.widgets.Input):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("attrs", {}).update(
-            {"class": "w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"}
+            {"class": "w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-800 text-gray-700 dark:text-white border-gray-300 dark:border-gray-600 dark:focus:ring-blue-400"}
         )
         super().__init__(*args, **kwargs)
 
@@ -296,7 +296,7 @@ class TailwindURLInput(URLInput):
     # This widget, subclassing URLInput, ensures input type="url"
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("attrs", {}).update(
-            {"class": "w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"}
+            {"class": "w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-800 text-gray-700 dark:text-white border-gray-300 dark:border-gray-600 dark:focus:ring-blue-400"}
         )
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Related issues :Fixes #578
Checklist:
done : Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
done : Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)

📝 Description
This PR resolves a dark mode styling issue for the TailwindURLInput widget.

In dark mode, the TailwindURLInput component lacked appropriate Tailwind CSS dark mode classes. As a result, the input fields—particularly URL fields—had light backgrounds and light text, making them unreadable.

✅ Solution
The following Tailwind dark mode classes were added:
dark:bg-gray-800: Sets a proper dark background
dark:text-white: Ensures readable text
dark:border-gray-600: Matches border styling used in other components
dark:focus:ring-blue-400: Provides a dark-mode-friendly focus ring
These styles align with those already used in TailwindTextarea, ensuring a consistent and accessible UI in dark mode.

✨ Result

With these changes, URL input fields now correctly adapt to dark mode—featuring dark backgrounds and light text—resolving the readability issue and improving the overall dark mode experience.