### PR TITLE
fix(calculator): sync graphing calculator theme with site preference …

### DIFF
--- a/web/templates/graphing_calculator.html
+++ b/web/templates/graphing_calculator.html
@@ -628,14 +628,24 @@
           link.click();
       }
 
-      // Set initial view and dark mode preference
       window.addEventListener('load', () => {
-          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          // Read theme from localStorage as string
+          const darkModeSetting = localStorage.getItem('darkMode');
+
+          // Convert it to a boolean (handle null case as fallback)
+          const prefersDark = darkModeSetting === 'true';
+
+          // Sync UI elements
           document.getElementById('darkMode').checked = prefersDark;
           isDarkMode = prefersDark;
+
+          // Apply or remove the dark class
           if (prefersDark) {
               document.documentElement.classList.add('dark');
+          } else {
+              document.documentElement.classList.remove('dark');
           }
+
           resetView();
       });
   </script>


### PR DESCRIPTION
## Related Issues

Fixes #610 

### Summary

This PR fixes the behavior where the graphing calculator always loads in dark mode regardless of the main site's current theme.

### What Changed

- The calculator now reads the user's selected theme from `localStorage` (`darkMode`)
- Applies or removes the `dark` class accordingly
- Syncs the dark mode checkbox state and resets the view on load

### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Tested in both light and dark themes
- [x] Matches the site's current theme on load
- [/] Added screenshots to the PR description (if applicable)

