### PR TITLE
feat(auth): add Google OAuth login functionality

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,9 @@ GIT_REPO=your_git_repo_to_deploy
 GIT_BRANCH=your_repo_branch
 ALLOWED_HOSTS=example.com,www.example.com,127.0.0.1,localhost
 CSRF_TRUSTED_ORIGINS=http://domain.com
+
+#google authentication
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=google-client-id
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=google-secret-key
+SOCIAL_AUTH_GOOGLE_OAUTH2_REDIRECT_URI=http://localhost:8000/social-auth/complete/google-oauth2/

--- a/web/settings.py
+++ b/web/settings.py
@@ -123,6 +123,7 @@ INSTALLED_APPS = [
     "allauth.account",
     "captcha",
     "markdownx",
+    "social_django",
     "web",
     "web.virtual_lab.apps.VirtualLabConfig",
 ]
@@ -142,6 +143,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    'social_django.middleware.SocialAuthExceptionMiddleware',
     "web.middleware.WebRequestMiddleware",
     # "web.middleware.GlobalExceptionMiddleware",
 ]
@@ -163,6 +165,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "web.context_processors.last_modified",
+                "social_django.context_processors.backends"
             ],
         },
     },
@@ -232,6 +235,7 @@ ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = "account_login"
 
 # Authentication backends
 AUTHENTICATION_BACKENDS = [
+    'social_core.backends.google.GoogleOAuth2',
     "django.contrib.auth.backends.ModelBackend",
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
@@ -395,3 +399,9 @@ USE_X_FORWARDED_HOST = True
 
 # GitHub API Token for fetching contributor data
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+
+
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=env.str("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY",default="")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET =env.str("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET",default="")
+SOCIAL_AUTH_GOOGLE_OAUTH2_REDIRECT_URI =env.str("SOCIAL_AUTH_GOOGLE_OAUTH2_REDIRECT_URI",default="")

--- a/web/templates/account/login.html
+++ b/web/templates/account/login.html
@@ -10,12 +10,12 @@
 {% block content %}
   <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-      <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
+      <h2 class="mt-2 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
         <i class="fas fa-sign-in-alt text-orange-500 mr-2"></i>
         Sign in to your account
       </h2>
     </div>
-    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="mt-4 sm:mx-auto sm:w-full sm:max-w-md">
       <form class="space-y-6" action="{% url 'account_login' %}" method="post">
         {% csrf_token %}
         {% if form.errors %}
@@ -34,7 +34,7 @@
             <i class="fas fa-envelope text-gray-400 mr-1"></i>
             Email Address
           </label>
-          <div class="mt-2">
+          <div class="mt-1">
             <input id="id_login"
                    name="login"
                    type="email"
@@ -67,7 +67,7 @@
                    {% if form.remember.value %}checked{% endif %}
                    class="h-4 w-4 text-orange-500 focus:ring-orange-500 border-gray-300 dark:border-gray-600 rounded cursor-pointer" />
             <label for="id_remember"
-                   class="ml-2 mt-2 block text-sm text-gray-900 dark:text-gray-200 cursor-pointer">Remember me</label>
+                   class="ml-2 mt-1 block text-sm text-gray-900 dark:text-gray-200 cursor-pointer">Remember me</label>
           </div>
           <div class="text-sm">
             <a href="{% url 'account_reset_password' %}"
@@ -87,13 +87,37 @@
           </button>
         </div>
       </form>
-      <p class="mt-10 text-center text-sm text-gray-500 dark:text-gray-400">
-        Don't have an account?
-        <a href="{% url 'account_signup' %}"
-           class="font-semibold leading-6 text-orange-500 hover:text-orange-600">
-          Sign up <i class="fas fa-arrow-right text-xs ml-1"></i>
-        </a>
-      </p>
+      </form>
+
+<!-- Divider -->
+<div class="relative my-6">
+  <div class="absolute inset-0 flex items-center">
+    <div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
+  </div>
+  <div class="relative flex justify-center text-sm">
+    <span class="bg-white dark:bg-gray-900 px-2 text-gray-500 dark:text-gray-400">or</span>
+  </div>
+</div>
+
+<!-- Google Login Button -->
+<div>
+  <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}"
+     class="flex w-full justify-center items-center gap-3 rounded-md bg-red-600 px-4 py-2 text-base font-semibold leading-6 text-white shadow-sm hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 transition-all duration-200">
+    <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google icon" class="w-5 h-5" />
+    Login with Google
+  </a>
+</div>
+
+<!-- Signup Link -->
+<p class="mt-10 text-center text-sm text-gray-500 dark:text-gray-400">
+  Don't have an account?
+  <a href="{% url 'account_signup' %}"
+     class="font-semibold leading-6 text-orange-500 hover:text-orange-600">
+    Sign up <i class="fas fa-arrow-right text-xs ml-1"></i>
+  </a>
+</p>
+
+
     </div>
   </div>
 {% endblock content %}

--- a/web/urls.py
+++ b/web/urls.py
@@ -86,8 +86,10 @@ urlpatterns += i18n_patterns(
     path("accounts/", include("allauth.urls")),
     path("account/notification-preferences/", notification_preferences, name="notification_preferences"),
     path("profile/", views.profile, name="profile"),
+    path('social-auth/', include('social_django.urls', namespace='social')),
     path("accounts/profile/", views.profile, name="accounts_profile"),
     path("accounts/delete/", views.delete_account, name="delete_account"),
+    
     # Dashboard URLs
     path("dashboard/student/", views.student_dashboard, name="student_dashboard"),
     path("dashboard/teacher/", views.teacher_dashboard, name="teacher_dashboard"),


### PR DESCRIPTION

## Related issues

Fixes #658 

### What’s changed

- 🚀 Added **Google OAuth login functionality** using Passport.js
- 🛠️ Updated `.env.sample` to include required Google OAuth credentials
- 🔧 Modified auth routes and controller to support third-party authentication

### Environment Variables

Make sure to add these to your `.env` file:

SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=google-client-id
SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=google-secret-key
SOCIAL_AUTH_GOOGLE_OAUTH2_REDIRECT_URI=http://localhost:8000/social-auth/complete/google-oauth2/


### Testing Notes

- Verified login flow with Google account
- Confirmed user creation and session persistence
- Checked redirect after successful login works as expected

### Screenshots
<img width="1897" height="952" alt="image" src="https://github.com/user-attachments/assets/45f5a813-6648-4f46-a340-6ff32fceb4dd" />
<img width="1891" height="958" alt="image" src="https://github.com/user-attachments/assets/8bcb296c-227a-4027-a26d-56c4fc4d7158" />
<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/16c500fb-99eb-4c9f-bf67-c65f4ae30f8f" />
<img width="1910" height="971" alt="image" src="https://github.com/user-attachments/assets/017a8326-cf86-4caa-a182-7bb42d64fb0d" />


