### PR TITLE
Feat/store empty state ux

### DIFF
--- a/web/templates/goods/goods_listing.html
+++ b/web/templates/goods/goods_listing.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% load custom_filters %}
 {% block title %}
   Explore Our Products
 {% endblock title %}
@@ -39,8 +39,13 @@
                     class="w-full border-gray-300 dark:border-gray-600 rounded-md shadow-sm dark:bg-gray-700 dark:text-white">
               <option value="">All</option>
               {% for name in store_names %}
-                <option value="{{ name }}"
-                        {% if request.GET.store_name == name %}selected{% endif %}>{{ name }}</option>
+                {% with count=store_product_counts|get_item:name %}
+                  <option value="{{ name }}"
+                          {% if count == 0 %}disabled title="No products available"{% endif %}
+                          {% if request.GET.store_name == name %}selected{% endif %}>
+                    {{ name }} {% if count == 0 %}(No products available){% else %}({{ count }} products available){% endif %}
+                  </option>
+                {% endwith %}
               {% endfor %}
             </select>
           </div>
@@ -142,7 +147,11 @@
           </div>
         {% empty %}
           <div class="text-gray-500 dark:text-gray-400 text-center col-span-full text-lg">
-            <p>No products found.</p>
+            {% if request.GET.store_name %}
+              <p>No products available in {{ request.GET.store_name }} at the moment.</p>
+            {% else %}
+              <p>No products available in this store at the moment.</p>
+            {% endif %}
           </div>
         {% endfor %}
       </section>

--- a/web/templatetags/custom_filters.py
+++ b/web/templatetags/custom_filters.py
@@ -1,0 +1,16 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def get_item(dictionary, key):
+    """
+    Custom template filter to access dictionary values by key.
+    Usage: {{ store_product_counts|get_item:name }}
+    Returns 0 if key doesn't exist.
+    """
+    if isinstance(dictionary, dict):
+        return dictionary.get(key, 0)
+    return 0

--- a/web/views.py
+++ b/web/views.py
@@ -3941,7 +3941,7 @@ class GoodsListingView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        stores_with_counts = Storefront.objects.annotate(product_count=Count('goods'))
+        stores_with_counts = Storefront.objects.annotate(product_count=Count("goods"))
         context["store_names"] = [store.name for store in stores_with_counts]
         context["store_product_counts"] = {store.name: store.product_count for store in stores_with_counts}
         context["categories"] = Goods.objects.values_list("category", flat=True).distinct()

--- a/web/views.py
+++ b/web/views.py
@@ -15,7 +15,7 @@ from collections import Counter, defaultdict
 from datetime import timedelta
 from decimal import Decimal
 from urllib.parse import urlparse
-
+from django.db.models import Count
 import requests
 import stripe
 import tweepy
@@ -3941,7 +3941,9 @@ class GoodsListingView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["store_names"] = Storefront.objects.values_list("name", flat=True).distinct()
+        stores_with_counts = Storefront.objects.annotate(product_count=Count('goods'))
+        context["store_names"] = [store.name for store in stores_with_counts]
+        context["store_product_counts"] = {store.name: store.product_count for store in stores_with_counts}
         context["categories"] = Goods.objects.values_list("category", flat=True).distinct()
 
         # Add cart count for each product


### PR DESCRIPTION
<!-- Please customize the sections below to describe your changes. Pull requests that don't fill out this template may be closed without further notice. -->

## Related issues

Fixes #612

---

###  Features Implemented

####  Clear Empty Store Message
Replaced the generic “No products found” with a clearer message:

> “No products available in Storefront for {store_name} at the moment.”

####  Store Product Availability in Dropdown
Each store in the dropdown now displays the number of products available:

> Storefront for teacher1 (3 products available)  
> Storefront for teacher2 (0 products available)

####  Disabled Empty Stores in Filter
Stores with 0 products are disabled to prevent selecting empty options.

####  Tooltip for Disabled Stores
Disabled stores show a tooltip:

> “No products available”

---

### 📸 Screenshots

<img width="1901" alt="Screenshot 2025-08-05 145529" src="https://github.com/user-attachments/assets/6242ab3e-2193-429e-9d3d-c494a908a4f9" />
<img width="1898" alt="Screenshot 2025-08-05 145606" src="https://github.com/user-attachments/assets/a7d3381c-e3db-487c-8ebc-ab143148a92e" />

---

###  Checklist

- [x] Did you run the pre-commit? **Yes**
- [x] Did you test the change? **Yes**
- [x] Added screenshots to the PR description? **Yes**
