### PR TITLE
fix(ui): improve hover contrast in dark mode for forum cards

### DIFF
--- a/web/templates/web/forum/categories.html
+++ b/web/templates/web/forum/categories.html
@@ -113,7 +113,7 @@
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm mb-6 divide-y divide-gray-200 dark:divide-gray-700">
             {% for category in categories %}
               {% for topic in category.topics.all|slice:":3" %}
-                <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors duration-150">
+                <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors duration-150">
                   <div class="flex items-start">
                     <!-- User Avatar -->
                     <div class="mr-4 hidden sm:block">

--- a/web/templates/web/forum/category.html
+++ b/web/templates/web/forum/category.html
@@ -128,7 +128,7 @@
           <!-- Topics List -->
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm divide-y divide-gray-200 dark:divide-gray-700">
             {% for topic in topics %}
-              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors duration-150">
+              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors duration-150">
                 <div class="flex items-start">
                   <!-- User Avatar -->
                   <div class="mr-4 hidden sm:block">

--- a/web/templates/web/forum/my_replies.html
+++ b/web/templates/web/forum/my_replies.html
@@ -96,7 +96,7 @@
           <!-- Replies List -->
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm divide-y divide-gray-200 dark:divide-gray-700">
             {% for reply in replies %}
-              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors duration-150">
+              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors duration-150">
                 <div class="flex items-start">
                   <!-- User Avatar -->
                   <div class="mr-4 hidden sm:block">

--- a/web/templates/web/forum/my_topics.html
+++ b/web/templates/web/forum/my_topics.html
@@ -96,7 +96,7 @@
           <!-- Topics List -->
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm divide-y divide-gray-200 dark:divide-gray-700">
             {% for topic in topics %}
-              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors duration-150">
+              <div class="p-4 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors duration-150">
                 <div class="flex items-start">
                   <!-- User Avatar -->
                   <div class="mr-4 hidden sm:block">


### PR DESCRIPTION

https://github.com/user-attachments/assets/055c3cec-2879-4cdb-a9db-95e1f072aafd

Closes #776 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dark mode hover states throughout forum discussions, including category lists, topic lists, and reply lists for improved visual contrast and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->