### PR TITLE
Fix #788: Add Virtual Labs link in mobile navigation

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -690,6 +690,11 @@
                        class="fas fa-chevron-down text-gray-500 dark:text-gray-400 transition-transform duration-200"></i>
                   </div>
                   <div id="resources-accordion" class="hidden mt-2 ml-2 space-y-2">
+                    <a href="{% url 'virtual_lab:virtual_lab_home' %}"
+                       class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
+                      <i class="fas fa-flask mr-2 text-teal-500"></i>
+                      <span>Virtual Lab</span>
+                    </a>
                     <a href="{% url 'progress_visualization' %}"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
                       <i class="fas fa-chart-line mr-2 text-teal-500"></i>


### PR DESCRIPTION

![Issue788](https://github.com/user-attachments/assets/ac946dfa-ee13-41e6-b90f-c2419e621a18)

- Added missing Virtual Labs link to the mobile navigation menu
- Verified the link appears correctly on mobile viewports

Fixes #788 

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual Lab page is now accessible directly from the Resources dropdown menu in the main navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->