### PR TITLE
fix(footer): update Discord and Slack links

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1019,7 +1019,7 @@
                      width="20"
                      height="20" />
               </a>
-              <a href="https://discord.gg/"
+              <a href="https://discord.gg/m2Tesq45"
                  target="_blank"
                  rel="noopener"
                  class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
@@ -1049,7 +1049,7 @@
                  class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                 <i class="fab fa-github text-xl"></i>
               </a>
-              <a href="https://join.slack.com/t/alphaonelabs/shared_invite/zt-7dvtocfr-1dYWOL0XZwEEPUeWXxrB1A"
+              <a href="https://join.slack.com/t/alphaonelabs/shared_invite/zt-3glzypiib-8Lq~UZwWvcCFAjeG5uwcPg"
                  target="_blank"
                  rel="noopener"
                  class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">


### PR DESCRIPTION
## Related issues

Fixes #807

## Summary

Fixes broken Discord and Slack links in the website footer by updating them to valid invite URLs.

### Checklist

- [x] Did you run the pre-commit?
- [x] Did you test the change?
- [/] Added screenshots to the PR description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated community social links in the header and footer to direct users to the latest Discord and Slack community invite pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->