### PR TITLE
Fix expired Slack invite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ If you encounter any issues or need support, please:
 
 1. Search existing [Issues](https://github.com/alphaonelabs/education-website/issues)
 2. Create a new issue if your problem persists
-3. Join us on Slack https://join.slack.com/t/alphaonelabs/shared_invite/zt-7dvtocfr-1dYWOL0XZwEEPUeWXxrB1A
+3. ⚠️ The Slack invite link may be expired.  
+   Please contact the maintainers or open an issue to request access.
 
 ## Acknowledgments
 


### PR DESCRIPTION
The Slack invite link in the Support section of README.md was expired and no longer usable.

This pull request updates the documentation to avoid confusion for new contributors by indicating that the Slack link may be expired and advising them to contact the maintainers or open an issue for access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support section guidance for Slack access requests. Direct Slack invite link replaced with instructions to contact maintainers or open an issue to request access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->