### PR TITLE
fix(materials): enforce enrollment on downloads

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -1933,6 +1933,21 @@ def download_material(request, slug, material_id):
     if not material.is_downloadable and request.user != material.course.teacher:
         return HttpResponseForbidden("This material is not available for download.")
 
+    if material.requires_enrollment:
+        is_teacher = request.user == material.course.teacher
+        is_enrolled = Enrollment.objects.filter(
+            student=request.user,
+            course=material.course,
+            status="approved",
+        ).exists()
+
+        if not (is_teacher or is_enrolled):
+            return HttpResponseForbidden("You must be enrolled to download this material.")
+
+    if not material.file:
+        messages.error(request, "This material does not have a downloadable file.")
+        return redirect("course_detail", slug=slug)
+
     try:
         return FileResponse(material.file, as_attachment=True)
     except FileNotFoundError:


### PR DESCRIPTION
Title
Fix restricted course material downloads

Summary
Enforce enrollment checks in `download_material` and handle missing file gracefully.

The student can able to access and download the course material even if he is not enrolled to the course
by hitting the url `http://127.0.0.1:8000/en/courses/<course-slug>/materials/<material-id>/download/`


fixes : #832 

Changes
Added `is_enrolled` and `is_teacher` boolean check for restricted materials.
Added guard for missing `material.file` to prevent 500 errors.

<img width="630" height="464" alt="Screenshot 2026-02-07 223742" src="https://github.com/user-attachments/assets/d90bd92e-3a55-406f-ad16-200f1e22a2be" />

Tests
python manage.py test (passed)
pre-commit (partially skipped: poetry-check failed due to missing mysqlclient system deps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access control enforcement for material downloads—users must meet enrollment requirements to download restricted materials.
  * Improved error handling for missing downloadable files with appropriate redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->