### PR TITLE
feat(quiz): add delete option button

### DIFF
--- a/web/templates/web/quiz/question_form.html
+++ b/web/templates/web/quiz/question_form.html
@@ -54,6 +54,11 @@
                   deleteBtn.disabled = shouldDisable;
                   deleteBtn.classList.toggle('opacity-50', shouldDisable);
                   deleteBtn.classList.toggle('cursor-not-allowed', shouldDisable);
+                  if (shouldDisable) {
+                      deleteBtn.setAttribute('title', 'At least two options are required');
+                  } else {
+                      deleteBtn.removeAttribute('title');
+                  }
               });
           }
 
@@ -300,7 +305,7 @@
                                  class="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">Correct</label>
                         </div>
                         <button type="button"
-                                class="delete-option-btn ml-4 text-red-600 hover:text-red-700 focus:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:text-red-300 dark:focus:ring-red-500 sm:ml-6 md:ml-8"
+                                class="delete-option-btn ml-4 rounded text-red-600 hover:text-red-700 focus:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:text-red-300 dark:focus:ring-red-500 sm:ml-6 md:ml-8"
                                 aria-label="Remove option">
                           <i class="fas fa-trash-alt"></i>
                         </button>


### PR DESCRIPTION
Adds a delete button for answer options and prevents deleting below two visible options.

## Related issues
Fixes #843 

### Checklist
- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)
<img width="1516" height="780" alt="image" src="https://github.com/user-attachments/assets/69904d7f-cfdb-4096-a57b-5c829576f047" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-option delete controls for quiz question forms, plus ability to append new options.
  * Improved initialization so delete buttons reflect the current state on load.
  * UI adjustments to option layout and correct-checkbox presentation.

* **Bug Fixes**
  * Enforce a minimum of two visible options; prevent deletion below that threshold.
  * Robust client-side handling when adding/removing options to preserve form integrity and indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->