### PR TITLE
fix(whiteboard): change button text from 'Load Image' to 'Upload Image' for clarity

### DIFF
--- a/web/templates/whiteboard.html
+++ b/web/templates/whiteboard.html
@@ -44,7 +44,7 @@
       </div>
       <!-- Upload (Load) and Download buttons -->
       <button id="uploadBoard"
-              class="px-4 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600">Load Image</button>
+              class="px-4 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600">Upload Image</button>
       <input type="file" id="loadInput" accept="image/*" style="display: none;" />
       <button id="downloadBoard"
               class="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600">Download</button>


### PR DESCRIPTION
Changed the whiteboard toolbar button text from "Load Image" to "Upload Image".

**Why:**
"Upload" is more intuitive for users, clearly indicating that they are selecting an image from their device to add to the whiteboard.

## Related issues

Fixes #850 

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [ ] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [ ] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)
<img width="1835" height="381" alt="Screenshot from 2026-02-12 15-03-00" src="https://github.com/user-attachments/assets/86451fa1-c222-4098-a832-692b8a4961e6" />
