### PR TITLE
chore: update gsoc links to 2026

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -304,11 +304,11 @@
                      class="block px-4 py-2 rounded-md text-gray-700 dark:text-gray-200 hover:bg-teal-50 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-300">
                     <i class="fas fa-shopping-basket mr-2 text-teal-500"></i>Storefronts
                   </a>
-                  <a href="https://github.com/alphaonelabs/education-website/wiki/GSOC-2025-Ideas"
+                  <a href="https://github.com/alphaonelabs/alphaonelabs-education-website/wiki/GSOC-2026-Ideas"
                      target="_blank"
                      rel="noopener"
                      class="block px-4 py-2 rounded-md text-gray-700 dark:text-gray-200 hover:bg-teal-50 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-300">
-                    <i class="fas fa-code mr-2 text-teal-500"></i>GSOC'25
+                    <i class="fas fa-code mr-2 text-teal-500"></i>GSOC'26
                   </a>
                 </div>
               </div>
@@ -715,12 +715,12 @@
                       <i class="fas fa-shopping-basket mr-2 text-teal-500"></i>
                       <span>Storefronts</span>
                     </a>
-                    <a href="https://github.com/alphaonelabs/education-website/wiki/GSOC-2025-Ideas"
+                    <a href="https://github.com/alphaonelabs/alphaonelabs-education-website/wiki/GSOC-2026-Ideas"
                        target="_blank"
                        rel="noopener"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
                       <i class="fas fa-code mr-2 text-teal-500"></i>
-                      <span>GSOC'25</span>
+                      <span>GSOC'26</span>
                     </a>
                   </div>
                 </div>
@@ -978,11 +978,11 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/alphaonelabs/education-website/wiki/GSOC-2025-Ideas"
+                <a href="https://github.com/alphaonelabs/alphaonelabs-education-website/wiki/GSOC-2026-Ideas"
                    target="_blank"
                    rel="noopener"
                    class="text-gray-600 dark:text-gray-300 hover:text-teal-600 dark:hover:text-teal-400 flex items-center">
-                  <i class="fas fa-code mr-2 text-teal-500 w-5 text-center"></i>GSOC'25
+                  <i class="fas fa-code mr-2 text-teal-500 w-5 text-center"></i>GSOC'26
                 </a>
               </li>
               <li>

--- a/web/templates/gsoc_landing_page.html
+++ b/web/templates/gsoc_landing_page.html
@@ -126,7 +126,7 @@
           <h3 class="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">🔍 Find the Right Project</h3>
           <p class="text-gray-600 dark:text-gray-300">
             Explore our
-            <a href="https://github.com/alphaonelabs/education-website/wiki/GSOC-2025-Ideas-Refined"
+            <a href="https://github.com/alphaonelabs/alphaonelabs-education-website/wiki/GSOC-2026-Ideas"
                target="_blank"
                rel="noopener noreferrer"
                class="text-orange-600 hover:text-orange-500 dark:text-orange-400 dark:hover:text-orange-300 transition-colors">


### PR DESCRIPTION
Update GSoC links and labels to 2026 across the site navigation and GSoC landing page.

## Related issues

Fixes #863 

### Checklist
- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)
<img width="400" height="334" alt="image" src="https://github.com/user-attachments/assets/e0aac137-2c4a-4f23-ba7d-ae2bce16c946" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all Google Summer of Code (GSOC) references and links from 2025 to 2026, ensuring users are directed to current program resources and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->