### PR TITLE
feat(ui): make course cards fully clickable

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -90,18 +90,18 @@
                  aria-label="{{ course.title }}"></a>
               <div class="aspect-square w-full relative overflow-hidden rounded-lg mb-3">
                 {% if course.image %}
-                  <a href="{% url 'course_detail' course.slug %}">
+                  <a href="{% url 'course_detail' course.slug %}" aria-hidden="true">
                     <img src="{{ course.image.url }}"
                          alt="{{ course.title }}"
-                         class="w-full h-full object-cover"
+                         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
                          height="300"
                          width="300" />
                   </a>
                 {% else %}
-                  <a href="{% url 'course_detail' course.slug %}">
+                  <a href="{% url 'course_detail' course.slug %}" aria-hidden="true">
                     <img src="{% static 'images/default-course.jpg' %}"
                          alt="{{ course.title }}"
-                         class="w-full h-full object-cover"
+                         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
                          height="300"
                          width="300" />
                   </a>
@@ -111,7 +111,8 @@
               <div class="mb-3">
                 <h3 class="text-lg font-semibold h-14 flex items-start">
                   <a href="{% url 'course_detail' course.slug %}"
-                     class="hover:text-orange-500 transition-colors duration-200 line-clamp-2">{{ course.title }}</a>
+                     class="hover:text-orange-500 transition-colors duration-200 line-clamp-2"
+                     aria-hidden="true">{{ course.title }}</a>
                 </h3>
                 <div class="flex items-center justify-between text-sm">
                   <span class="font-medium text-teal-600 dark:text-teal-400">{{ course.subject }}</span>


### PR DESCRIPTION
<!-- Please customize the sections below to describe your changes. Pull requests that don't fill out this template may be closed without further notice. -->

<!-- Link the issue using the "Fixes" keyword. Example: Fixes #1234 -->

## Related issues

Fixes #898 

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

 Make Entire Course Card Clickable in Recent Courses Section

## Problem
Users could only click on the course image or title to navigate to course details, making the cards feel less interactive and potentially confusing from a UX perspective.

## Solution
- **Expanded clickable area**: The entire course card is now clickable, not just the image and title
- **Enhanced hover effects**: Added smooth transitions for border color, shadow, and image scaling
- **Preserved functionality**: "Add to Cart" button still works independently with proper click event handling



## Screenshots
check screen recording it shows before and after


https://github.com/user-attachments/assets/8db10067-ca32-4ef8-9981-eb6664821889



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course cards are fully clickable via a full-card overlay and include hover border/shadow effects for clearer affordance and navigation to course details.

* **Accessibility**
  * Improved screen-reader behavior and aria attributes for images and links to better reflect visibility and intent.

* **Bug Fixes**
  * Add to Cart form and button now sit above the clickable overlay, preventing accidental navigation; the button also has hover transition feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->