### PR TITLE
fix: session calendar month navigation not working on course detail page

### DIFF
--- a/web/templates/courses/detail.html
+++ b/web/templates/courses/detail.html
@@ -442,11 +442,13 @@
                   <h3 class="text-sm font-semibold">Session Calendar</h3>
                   <div class="flex items-center space-x-4">
                     <button id="prev-month-btn"
+                            onclick="loadCalendar({{ prev_month.year }}, {{ prev_month.month }})"
                             class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
                       <i class="fas fa-chevron-left"></i>
                     </button>
                     <span class="text-sm font-medium" id="current-month">{{ current_month|date:"F Y" }}</span>
                     <button id="next-month-btn"
+                            onclick="loadCalendar({{ next_month.year }}, {{ next_month.month }})"
                             class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
                       <i class="fas fa-chevron-right"></i>
                     </button>
@@ -1505,7 +1507,7 @@
       }
 
       function loadCalendar(year, month) {
-          fetch(`/courses/{{ course.slug }}/calendar/?year=${year}&month=${month}`)
+          fetch(`{% url 'course_calendar' course.slug %}?year=${year}&month=${month}`)
               .then(response => response.json())
               .then(data => {
                   // Update month display


### PR DESCRIPTION
## Related issues

Fixes #902

### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn't just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

### Problem

The session calendar's previous/next month navigation buttons on the course detail page did not work. Clicking the left or right arrows had no visible effect - the calendar remained stuck on the current month.

### Solution

- **Added `onclick` handlers**: The previous/next month buttons now have initial `onclick` handlers using Django template variables, so they work on first page load
- **Fixed fetch URL**: Changed from a hardcoded path (`/courses/.../calendar/`) to Django's `{% url %}` template tag, which correctly includes the `/en/` language prefix and prevents silent 404 errors

### Screenshots

view attached screen recording as it shows before and after

https://github.com/user-attachments/assets/91e21151-b7fa-4a9b-891a-fcfa4036c656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the calendar navigation system to use more robust URL handling, ensuring calendar views load correctly when navigating between months.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->