### PR TITLE
Optimize redundant group.members.all DB queries in study group detail

### DIFF
--- a/web/templates/web/study/group_detail.html
+++ b/web/templates/web/study/group_detail.html
@@ -81,7 +81,7 @@
                 </form>
               </div>
             {% endif %}
-            {% if request.user in group.members.all %}
+            {% if is_member %}
               <div class="bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-200 p-4 rounded-lg">
                 <div class="flex justify-between items-center">
                   <div>You are a member of this group</div>
@@ -126,7 +126,7 @@
             </h2>
           </div>
           <div class="divide-y divide-gray-200 dark:divide-gray-700">
-            {% for member in group.members.all %}
+            {% for member in members %}
               <div class="p-4">
                 <div class="flex items-center">
                   {% if member.profile.avatar %}
@@ -158,7 +158,7 @@
           </div>
         </div>
       </div>
-      {% if request.user in group.members.all %}
+      {% if is_member %}
         <div class="mt-6">
           <div class="border border-gray-300 rounded p-4">
             <h2 class="text-lg font-semibold mb-2">Invite Friends</h2>

--- a/web/views.py
+++ b/web/views.py
@@ -2277,7 +2277,18 @@ def study_group_detail(request, group_id):
                 group.members.remove(request.user)
                 messages.info(request, f"You have left {group.name}.")
 
-    return render(request, "web/study/group_detail.html", {"group": group})
+    members = list(group.members.all())
+    is_member = request.user in members
+
+    return render(
+        request,
+        "web/study/group_detail.html",
+        {
+            "group": group,
+            "members": members,
+            "is_member": is_member,
+        },
+    )
 
 
 # API Views


### PR DESCRIPTION
## Related issues

Fixes #921 

### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

### Summary

Optimized the `study_group_detail` view and its template to eliminate redundant database queries caused by multiple evaluations of `group.members.all` in Django template tags.

### Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| DB queries for members | 3 | 1 |
| Template membership checks | queryset eval | boolean lookup |

### Testing

- All existing study group tests pass (`web.tests.test_study_groups`)
- All pre-commit hooks pass (black, isort, flake8, djlint)
- No functional behavior change - purely a performance optimization

### Context

This optimization was originally flagged by CodeRabbit during the review of PR #908  (styling fix for issue #907). It was intentionally deferred to this separate PR to keep the original PR focused on its scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Invite Friends" section on study group pages, visible only to group members (invite by email or username).
* **Refactor**
  * Membership checks updated to consistently control visibility of the Group Settings header and Members list, improving when member-only sections appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->