### PR TITLE
Fix Physics dropdown and add missing experiments in Virtual Lab nav.

### DIFF
--- a/web/virtual_lab/templates/virtual_lab/layout.html
+++ b/web/virtual_lab/templates/virtual_lab/layout.html
@@ -16,17 +16,21 @@
           <a href="{% url 'virtual_lab:virtual_lab_home' %}"
              class="hover:text-indigo-600 dark:hover:text-indigo-400 transition">{% trans "Home" %}</a>
           <!-- Physics Dropdown -->
-          <div class="relative group inline-block">
+          <div class="relative z-50 group inline-block">
             <button class="hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500">
               {% trans "Physics" %}
             </button>
-            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto">
+            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto z-50">
               <a href="{% url 'virtual_lab:physics_pendulum' %}"
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition">{% trans "Pendulum" %}</a>
               <a href="{% url 'virtual_lab:physics_projectile' %}"
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-green-50 dark:hover:bg-green-900 transition">{% trans "Projectile" %}</a>
               <a href="{% url 'virtual_lab:physics_inclined' %}"
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-yellow-50 dark:hover:bg-yellow-900 transition">{% trans "Inclined Plane" %}</a>
+              <a href="{% url 'virtual_lab:physics_mass_spring' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-purple-50 dark:hover:bg-purple-900 transition">{% trans "Mass–Spring" %}</a>
+              <a href="{% url 'virtual_lab:physics_electrical_circuit' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900 transition">{% trans "Circuit" %}</a>
             </div>
           </div>
           <a href="{% url 'virtual_lab:chemistry_home' %}"

--- a/web/virtual_lab/templates/virtual_lab/layout.html
+++ b/web/virtual_lab/templates/virtual_lab/layout.html
@@ -20,7 +20,7 @@
             <button class="hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500">
               {% trans "Physics" %}
             </button>
-            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto z-50">
+            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-[opacity,visibility] pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto z-50">
               <a href="{% url 'virtual_lab:physics_pendulum' %}"
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition">{% trans "Pendulum" %}</a>
               <a href="{% url 'virtual_lab:physics_projectile' %}"


### PR DESCRIPTION
## Related issues

Fixes #929 

### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

### Summary

Fixed the Physics dropdown menu in the Virtual Lab navigation being hidden behind page content and added missing experiment links as well.


### Before / After

| Issue | Before | After |
|-------|--------|-------|
| Dropdown visibility | Hidden behind experiment cards | Renders above all content |
| Dropdown items | 3 (Pendulum, Projectile, Inclined Plane) | 5 (+ Mass-Spring, Circuit) |

### Testing

- Verified dropdown appears above all content on hover
- Verified all 5 dropdown links are clickable and navigate correctly

### Screenshots
The attached video shows the behavior after the fix. To see how it was before the fix, please refer to the recording in the issue #929.

https://github.com/user-attachments/assets/75d2d12b-4fd4-4aee-b185-8ec4e03fdfd7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Mass–Spring" and "Circuit" options to the Physics dropdown menu in navigation.

* **Bug Fixes**
  * Fixed dropdown display stacking and visibility so the Physics menu shows reliably above other page elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->