### PR TITLE
feat(virtual-lab): add dropdown menu for Chemistry experiments

### DIFF
--- a/web/virtual_lab/templates/virtual_lab/layout.html
+++ b/web/virtual_lab/templates/virtual_lab/layout.html
@@ -20,7 +20,8 @@
             <button class="hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500">
               {% trans "Physics" %}
             </button>
-            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto">
+            
+             <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto ">      
               <a href="{% url 'virtual_lab:physics_pendulum' %}"
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition">{% trans "Pendulum" %}</a>
               <a href="{% url 'virtual_lab:physics_projectile' %}"
@@ -29,9 +30,25 @@
                  class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-yellow-50 dark:hover:bg-yellow-900 transition">{% trans "Inclined Plane" %}</a>
             </div>
           </div>
-          <a href="{% url 'virtual_lab:chemistry_home' %}"
-             class="hover:text-indigo-600 dark:hover:text-indigo-400 transition">{% trans "Chemistry" %}</a>
-          <a href="{% url 'virtual_lab:code_editor' %}"
+          <!-- Chemistry Dropdown -->
+          <div class="relative group inline-block">
+            <button class="hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              {% trans "Chemistry" %}
+            </button>
+            <div class="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto z-50">
+              <a href="{% url 'virtual_lab:titration' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition">{% trans "Titration" %}</a>
+              <a href="{% url 'virtual_lab:reaction_rate' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-green-50 dark:hover:bg-green-900 transition">{% trans "Reaction Rate" %}</a>
+              <a href="{% url 'virtual_lab:solubility' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-yellow-50 dark:hover:bg-yellow-900 transition">{% trans "Solubility" %}</a>
+              <a href="{% url 'virtual_lab:precipitation' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-purple-50 dark:hover:bg-purple-900 transition">{% trans "Precipitation" %}</a>
+              <a href="{% url 'virtual_lab:ph_indicator' %}"
+                 class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900 transition">{% trans "pH Indicator" %}</a>
+            </div>
+          </div>
+           <a href="{% url 'virtual_lab:code_editor' %}"
              class="hover:text-indigo-600 dark:hover:text-indigo-400 transition">{% trans "Code Editor" %}</a>
         </nav>
       </div>


### PR DESCRIPTION
## Description

This PR enhances the Virtual Lab navigation by replacing the static "Chemistry" link with a fully functional dropdown menu, providing direct access to all chemistry experiments.

## Key Changes:

*   **UI/UX:**
    *   Replaced the single "Chemistry" navigation link with an interactive dropdown menu.
    *   Added menu items for:
    
        *   **Titration**
        *   **Reaction Rate**
        *   **Solubility**
        *   **Precipitation**
        *   **pH Indicator**
    *   Applied consistent styling (`w-40`, `z-50`, hover states) to match the existing Physics dropdown for a unified user experience.

## Related issues

Fixes #934 

https://github.com/user-attachments/assets/f2620a98-74a2-4948-ab6d-89e3a5d8ded6



### Checklist



- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chemistry navigation has been enhanced with a dropdown menu, replacing the previous single link. Users can now easily access five chemistry-focused modules: Titration, Reaction Rate, Solubility, Precipitation, and pH Indicator, providing improved organization and discoverability of chemistry-related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->