### PR TITLE
Add hover effects to quizzes list category cards

### DIFF
--- a/web/templates/web/quiz/quiz_list.html
+++ b/web/templates/web/quiz/quiz_list.html
@@ -24,7 +24,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <!-- Left column - My Quizzes -->
       <div class="lg:col-span-1">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden transition-all duration-300 hover:shadow-2xl hover:-translate-y-1">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden transition duration-300 hover:shadow-2xl motion-safe:hover:-translate-y-1">
           <div class="bg-teal-600 p-4">
             <h2 class="text-xl font-bold text-white flex items-center">
               <i class="fas fa-book mr-2"></i> My Quizzes
@@ -72,7 +72,7 @@
       </div>
       <!-- Middle column - Shared Quizzes -->
       <div class="lg:col-span-1">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden h-full transition-all duration-300 hover:shadow-2xl hover:-translate-y-1">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden h-full transition duration-300 hover:shadow-2xl motion-safe:hover:-translate-y-1">
           <div class="bg-blue-600 p-4">
             <h2 class="text-xl font-bold text-white flex items-center">
               <i class="fas fa-share-alt mr-2"></i> Shared With Me
@@ -113,7 +113,7 @@
       </div>
       <!-- Right column - Public Quizzes -->
       <div class="lg:col-span-1">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden h-full transition-all duration-300 hover:shadow-2xl hover:-translate-y-1">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden h-full transition duration-300 hover:shadow-2xl motion-safe:hover:-translate-y-1">
           <div class="bg-purple-600 p-4">
             <h2 class="text-xl font-bold text-white flex items-center">
               <i class="fas fa-globe mr-2"></i> Public Quizzes


### PR DESCRIPTION


## Related issues

Fixes #943 



- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


### Summary

Added hover interaction effects to the three quiz category cards **(My Quizzes, Shared With Me, Public Quizzes)** on the quiz list page. Each card now smoothly lifts up and gains a deeper shadow when hovered, providing clear visual feedback that improves the user experience. 


### Before & After

| | Before | After |
|---|---|---|
| **Hover behavior** | No visual change | Card lifts up and shadow deepens |
| **Transition** | None | Smooth 300ms animation |
| **Shadow** | `shadow-lg` (static) | `shadow-lg` → `shadow-2xl` on hover |
| **Position** | Static | Moves up 4px (`-translate-y-1`) on hover |

### Screenshots
The attached video shows the behavior after the fix. To see how it was before the fix, please refer to the recording in the issue #943 

https://github.com/user-attachments/assets/e1e2898e-61a2-48f3-a4ff-3e84bcc29217



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual feedback on quiz cards across My Quizzes, Shared With Me, and Public Quizzes with smooth hover transitions, enhanced shadows, and subtle lift animations for a more responsive, polished user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->