### PR TITLE
feat: add session details tooltip to course detail calendar

### DIFF
--- a/web/templates/courses/detail.html
+++ b/web/templates/courses/detail.html
@@ -455,7 +455,7 @@
                   </div>
                 </div>
                 <div id="calendar-container"
-                     class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 overflow-hidden">
+                     class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 overflow-visible">
                   <div class="grid grid-cols-7 text-center text-xs font-medium border-b dark:border-gray-700">
                     <div class="py-2">Sun</div>
                     <div class="py-2">Mon</div>
@@ -470,12 +470,26 @@
                       {% for day in week %}
                         <div class="p-2 border-b border-r dark:border-gray-700 {% if day.is_today %}bg-gray-100 dark:bg-gray-700{% endif %}">
                           {% if day.date %}
-                            <div class="relative">
-                              <span class="{% if day.has_session %}font-bold text-teal-600 dark:text-teal-400{% endif %}">
+                            <div class="relative group">
+                              <span class="{% if day.has_session %}font-bold text-teal-600 dark:text-teal-400 cursor-pointer{% endif %}">
                                 {{ day.date|date:"j" }}
                               </span>
                               {% if day.has_session %}
                                 <div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-teal-500 dark:bg-teal-400 rounded-full">
+                                </div>
+                                <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
+                                  <div class="bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg py-2 px-3 whitespace-nowrap shadow-lg border border-gray-700 dark:border-gray-600">
+                                    {% for session in day.sessions %}
+                                      <div class="{% if not forloop.first %}mt-1.5 pt-1.5 border-t border-gray-600{% endif %}">
+                                        <div class="font-semibold text-teal-300">{{ session.title }}</div>
+                                        <div class="text-gray-300 mt-0.5">
+                                          <i class="fas fa-clock mr-1 text-gray-400"></i>{{ session.start_time }} - {{ session.end_time }}
+                                        </div>
+                                      </div>
+                                    {% endfor %}
+                                    <div class="absolute top-full left-1/2 transform -translate-x-1/2 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900 dark:border-t-gray-700">
+                                    </div>
+                                  </div>
                                 </div>
                               {% endif %}
                             </div>
@@ -1519,16 +1533,36 @@
 
                   data.calendar_weeks.forEach(week => {
                       week.forEach(day => {
-                          const today = day.is_today ? 'bg-gray-100 dark:bg-gray-700' : '';
+                          const todayCls = day.is_today ? 'bg-gray-100 dark:bg-gray-700' : '';
+                          let tooltipHtml = '';
+                          if (day.has_session && day.sessions && day.sessions.length > 0) {
+                              const items = day.sessions.map((s, i) => {
+                                  const sep = i > 0 ? 'mt-1.5 pt-1.5 border-t border-gray-600' : '';
+                                  return `<div class="${sep}">
+                                      <div class="font-semibold text-teal-300">${s.title}</div>
+                                      <div class="text-gray-300 mt-0.5">
+                                          <i class="fas fa-clock mr-1 text-gray-400"></i>${s.start_time} - ${s.end_time}
+                                      </div>
+                                  </div>`;
+                              }).join('');
+                              tooltipHtml = `
+                                  <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
+                                      <div class="bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg py-2 px-3 whitespace-nowrap shadow-lg border border-gray-700 dark:border-gray-600">
+                                          ${items}
+                                          <div class="absolute top-full left-1/2 transform -translate-x-1/2 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+                                      </div>
+                                  </div>`;
+                          }
                           html += `
-            <div class="p-2 border-b border-r dark:border-gray-700 ${today}">
+            <div class="p-2 border-b border-r dark:border-gray-700 ${todayCls}">
               ${day.date ? `
-                <div class="relative">
-                  <span class="${day.has_session ? 'font-bold text-teal-600 dark:text-teal-400' : ''}">
+                <div class="relative group">
+                  <span class="${day.has_session ? 'font-bold text-teal-600 dark:text-teal-400 cursor-pointer' : ''}">
                     ${day.date.split('-')[2].replace(/^0/, '')}
                   </span>
                   ${day.has_session ? `
                     <div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-teal-500 dark:bg-teal-400 rounded-full"></div>
+                    ${tooltipHtml}
                   ` : ''}
                 </div>
               ` : ''}

--- a/web/templates/courses/detail.html
+++ b/web/templates/courses/detail.html
@@ -471,13 +471,16 @@
                         <div class="p-2 border-b border-r dark:border-gray-700 {% if day.is_today %}bg-gray-100 dark:bg-gray-700{% endif %}">
                           {% if day.date %}
                             <div class="relative group">
-                              <span class="{% if day.has_session %}font-bold text-teal-600 dark:text-teal-400 cursor-pointer{% endif %}">
+                              <span class="{% if day.has_session %}font-bold text-teal-600 dark:text-teal-400 cursor-pointer{% endif %}"
+                                    {% if day.has_session %}aria-describedby="tooltip-{{ day.date|date:'Y-m-d' }}"{% endif %}>
                                 {{ day.date|date:"j" }}
                               </span>
                               {% if day.has_session %}
                                 <div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-teal-500 dark:bg-teal-400 rounded-full">
                                 </div>
-                                <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
+                                <div id="tooltip-{{ day.date|date:'Y-m-d' }}"
+                                     role="tooltip"
+                                     class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
                                   <div class="bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg py-2 px-3 whitespace-nowrap shadow-lg border border-gray-700 dark:border-gray-600">
                                     {% for session in day.sessions %}
                                       <div class="{% if not forloop.first %}mt-1.5 pt-1.5 border-t border-gray-600{% endif %}">
@@ -1531,33 +1534,41 @@
                   const grid = document.getElementById('calendar-grid');
                   let html = '';
 
+                  function escapeHtml(text) {
+                      const div = document.createElement('div');
+                      div.appendChild(document.createTextNode(text));
+                      return div.innerHTML;
+                  }
+
                   data.calendar_weeks.forEach(week => {
                       week.forEach(day => {
                           const todayCls = day.is_today ? 'bg-gray-100 dark:bg-gray-700' : '';
                           let tooltipHtml = '';
                           if (day.has_session && day.sessions && day.sessions.length > 0) {
+                              const tooltipId = `tooltip-${day.date}`;
                               const items = day.sessions.map((s, i) => {
                                   const sep = i > 0 ? 'mt-1.5 pt-1.5 border-t border-gray-600' : '';
                                   return `<div class="${sep}">
-                                      <div class="font-semibold text-teal-300">${s.title}</div>
+                                      <div class="font-semibold text-teal-300">${escapeHtml(s.title)}</div>
                                       <div class="text-gray-300 mt-0.5">
-                                          <i class="fas fa-clock mr-1 text-gray-400"></i>${s.start_time} - ${s.end_time}
+                                          <i class="fas fa-clock mr-1 text-gray-400"></i>${escapeHtml(s.start_time)} - ${escapeHtml(s.end_time)}
                                       </div>
                                   </div>`;
                               }).join('');
                               tooltipHtml = `
-                                  <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
+                                  <div id="${tooltipId}" role="tooltip" class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-50">
                                       <div class="bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg py-2 px-3 whitespace-nowrap shadow-lg border border-gray-700 dark:border-gray-600">
                                           ${items}
                                           <div class="absolute top-full left-1/2 transform -translate-x-1/2 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
                                       </div>
                                   </div>`;
                           }
+                          const ariaAttr = day.has_session && day.date ? `aria-describedby="tooltip-${day.date}"` : '';
                           html += `
             <div class="p-2 border-b border-r dark:border-gray-700 ${todayCls}">
               ${day.date ? `
                 <div class="relative group">
-                  <span class="${day.has_session ? 'font-bold text-teal-600 dark:text-teal-400 cursor-pointer' : ''}">
+                  <span class="${day.has_session ? 'font-bold text-teal-600 dark:text-teal-400 cursor-pointer' : ''}" ${ariaAttr}>
                     ${day.date.split('-')[2].replace(/^0/, '')}
                   </span>
                   ${day.has_session ? `

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -561,7 +561,7 @@ class CourseDetailTests(TestCase):
         self.assertContains(response, "Completed")
 
     def test_calendar_display(self):
-        """Test that the session calendar is correctly displayed"""
+        """Test that the session calendar is correctly displayed with session details for tooltips"""
         # Request the calendar for the month containing the session
         session_month = self.future_session.start_time.month
         session_year = self.future_session.start_time.year
@@ -581,12 +581,52 @@ class CourseDetailTests(TestCase):
             for day in week:
                 if day["date"] and day["date"] == session_date:
                     self.assertTrue(day["has_session"])
+                    # Verify session details are included for tooltip
+                    self.assertIn("sessions", day)
+                    self.assertTrue(len(day["sessions"]) > 0)
+                    session_info = day["sessions"][0]
+                    self.assertIn("title", session_info)
+                    self.assertIn("start_time", session_info)
+                    self.assertIn("end_time", session_info)
+                    self.assertEqual(session_info["title"], self.future_session.title)
                     session_day_found = True
                     break
             if session_day_found:
                 break
 
         self.assertTrue(session_day_found, "Session date not found in calendar")
+
+    def test_calendar_ajax_endpoint(self):
+        """Test that the AJAX calendar endpoint returns session details for tooltips"""
+        session_month = self.future_session.start_time.month
+        session_year = self.future_session.start_time.year
+        url = reverse("course_calendar", args=[self.course.slug])
+        response = self.client.get(f"{url}?year={session_year}&month={session_month}")
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIn("calendar_weeks", data)
+        self.assertIn("current_month", data)
+
+        # Find the session day in the JSON response
+        session_date = self.future_session.start_time.date()
+        session_day_found = False
+        for week in data["calendar_weeks"]:
+            for day in week:
+                if day["date"] and day["date"] == session_date.isoformat():
+                    self.assertTrue(day["has_session"])
+                    self.assertIn("sessions", day)
+                    self.assertTrue(len(day["sessions"]) > 0)
+                    session_info = day["sessions"][0]
+                    self.assertEqual(session_info["title"], self.future_session.title)
+                    self.assertIn("start_time", session_info)
+                    self.assertIn("end_time", session_info)
+                    session_day_found = True
+                    break
+            if session_day_found:
+                break
+
+        self.assertTrue(session_day_found, "Session date not found in AJAX calendar response")
 
     def test_session_completion_form(self):
         """Test session completion form for enrolled students"""

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -583,7 +583,7 @@ class CourseDetailTests(TestCase):
                     self.assertTrue(day["has_session"])
                     # Verify session details are included for tooltip
                     self.assertIn("sessions", day)
-                    self.assertTrue(len(day["sessions"]) > 0)
+                    self.assertGreater(len(day["sessions"]), 0)
                     session_info = day["sessions"][0]
                     self.assertIn("title", session_info)
                     self.assertIn("start_time", session_info)
@@ -616,7 +616,7 @@ class CourseDetailTests(TestCase):
                 if day["date"] and day["date"] == session_date.isoformat():
                     self.assertTrue(day["has_session"])
                     self.assertIn("sessions", day)
-                    self.assertTrue(len(day["sessions"]) > 0)
+                    self.assertGreater(len(day["sessions"]), 0)
                     session_info = day["sessions"][0]
                     self.assertEqual(session_info["title"], self.future_session.title)
                     self.assertIn("start_time", session_info)

--- a/web/views.py
+++ b/web/views.py
@@ -850,7 +850,15 @@ def course_detail(request, slug):
         calendar_week = []
         for day in week:
             if day == 0:
-                calendar_week.append({"date": None, "in_month": False, "has_session": False, "sessions": []})
+                calendar_week.append(
+                    {
+                        "date": None,
+                        "in_month": False,
+                        "has_session": False,
+                        "is_today": False,
+                        "sessions": [],
+                    }
+                )
             else:
                 date = current_month.replace(day=day)
                 day_sessions = session_map.get(date, [])

--- a/web/views.py
+++ b/web/views.py
@@ -827,12 +827,22 @@ def course_detail(request, slug):
     # Get the calendar for current month
     cal = calendar.monthcalendar(current_month.year, current_month.month)
 
-    # Get all session dates for this course in current month
-    session_dates = set(
-        session.start_time.date()
-        for session in sessions
-        if session.start_time.year == current_month.year and session.start_time.month == current_month.month
-    )
+    # Get all sessions for this course in current month, grouped by date
+    month_sessions = [
+        s for s in sessions if s.start_time.year == current_month.year and s.start_time.month == current_month.month
+    ]
+    session_map = {}
+    for s in month_sessions:
+        d = s.start_time.date()
+        if d not in session_map:
+            session_map[d] = []
+        session_map[d].append(
+            {
+                "title": s.title,
+                "start_time": s.start_time.strftime("%I:%M %p"),
+                "end_time": s.end_time.strftime("%I:%M %p"),
+            }
+        )
 
     # Prepare calendar weeks data
     calendar_weeks = []
@@ -840,10 +850,19 @@ def course_detail(request, slug):
         calendar_week = []
         for day in week:
             if day == 0:
-                calendar_week.append({"date": None, "in_month": False, "has_session": False})
+                calendar_week.append({"date": None, "in_month": False, "has_session": False, "sessions": []})
             else:
                 date = current_month.replace(day=day)
-                calendar_week.append({"date": date, "in_month": True, "has_session": date in session_dates})
+                day_sessions = session_map.get(date, [])
+                calendar_week.append(
+                    {
+                        "date": date,
+                        "in_month": True,
+                        "has_session": bool(day_sessions),
+                        "is_today": date == today,
+                        "sessions": day_sessions,
+                    }
+                )
         calendar_weeks.append(calendar_week)
 
     # Check if the current user has already reviewed this course
@@ -3359,7 +3378,7 @@ def get_course_calendar(request, slug):
         calendar_week = []
         for day in week:
             if day == 0:
-                calendar_week.append({"date": None, "has_session": False, "is_today": False})
+                calendar_week.append({"date": None, "has_session": False, "is_today": False, "sessions": []})
             else:
                 date = timezone.datetime(year, month, day).date()
                 sessions_on_day = [s for s in month_sessions if s.start_time.date() == date]
@@ -3368,6 +3387,14 @@ def get_course_calendar(request, slug):
                         "date": date.isoformat() if date else None,
                         "has_session": bool(sessions_on_day),
                         "is_today": date == today,
+                        "sessions": [
+                            {
+                                "title": s.title,
+                                "start_time": s.start_time.strftime("%I:%M %p"),
+                                "end_time": s.end_time.strftime("%I:%M %p"),
+                            }
+                            for s in sessions_on_day
+                        ],
                     }
                 )
         calendar_weeks.append(calendar_week)


### PR DESCRIPTION
## Related issues

Fixes #954 

### Checklist
- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

### Problem
The session calendar on the course detail page highlights dates with sessions (teal text + dot indicator), but hovering over those dates provides no information about which session is scheduled. Users must scroll to the sessions list to find out.

### Solution
Added hover tooltips to calendar dates showing session title and time range.

### Screenshots
#### Before:
<img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/1e02b0de-12f1-429f-9175-ed6340dd969c" />

#### After:
<img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/0094539a-645d-4808-a2a1-b5a0e47bb9cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course calendar now shows hoverable tooltips for days with sessions, listing session titles and start/end times; day labels become clickable when sessions exist.
* **Improvements**
  * Calendar container allows content to overflow for proper tooltip rendering; today highlighting and session indicators preserved.
* **Tests**
  * Added/updated tests to verify per-day tooltip-ready session data in rendered HTML and AJAX calendar responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->