### PR TITLE
Add Issue Templates to .github

### DIFF
--- a/.github/ISSUE_TEMPLATE/01.bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01.bug-report.yml
@@ -1,0 +1,57 @@
+name: 🐛 Bug Report
+description: Create a report to help us improve
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your issue
+      placeholder: Example - When I click here this happens...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. Scroll down to...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      placeholder: A clear and concise description of what you expected to happen.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Put here any screenshots or videos (optional)
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context about the problem here.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing Issues
+      options:
+        - label: I have looked for similar issues and couldn't find any.
+          required: true
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this issue?"
+      options:
+        - "Yes"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this issue! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/02.feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02.feature-request.yml
@@ -1,0 +1,61 @@
+name: 💡 Feature Request
+description: Suggest an idea or enhancement for this project
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to suggest a new feature! Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      placeholder: A clear and concise description of the feature you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem it solves
+      placeholder: Describe the problem or limitation this feature would address. Example - I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      placeholder: Describe how you'd like this feature to work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      placeholder: Describe any alternative solutions or features you've considered.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Mockups or Screenshots (optional)
+      placeholder: Add any visual references, mockups, or screenshots to help explain your idea.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context about the feature request here.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing Issues
+      options:
+        - label: I have looked for similar issues and couldn't find any.
+          required: true
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this feature?"
+      options:
+        - "Yes"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your suggestion! We will review it as soon as possible.

--- a/.github/ISSUE_TEMPLATE/03.documentation-update-fix.yml
+++ b/.github/ISSUE_TEMPLATE/03.documentation-update-fix.yml
@@ -1,0 +1,59 @@
+name: 📝 Documentation Update or Fix
+description: Report outdated, incorrect, or missing documentation
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us keep our documentation accurate and up to date! Please fill out the sections below.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of Documentation Change
+      options:
+        - Fix (incorrect or outdated information)
+        - Update (existing docs need refreshing)
+        - Addition (missing documentation)
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation Location
+      placeholder: Link to the page or file, or describe where the documentation is located.
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Issue or Improvement
+      placeholder: What is wrong, outdated, or missing? Be as specific as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested Change
+      placeholder: Describe or paste the corrected/updated content you'd like to see.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context, references, or screenshots here.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing Issues
+      options:
+        - label: I have looked for similar issues and couldn't find any.
+          required: true
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this issue?"
+      options:
+        - "Yes"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation! We will review your suggestion as soon as possible.

--- a/.github/ISSUE_TEMPLATE/04.refactor-request.yml
+++ b/.github/ISSUE_TEMPLATE/04.refactor-request.yml
@@ -1,0 +1,72 @@
+name: 🛠️ Refactor Request
+description: Suggest a code refactor for maintainability, readability, or performance
+labels: ["refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the codebase! Please describe the refactor you'd like to suggest.
+  - type: dropdown
+    id: goal
+    attributes:
+      label: Refactor Goal
+      options:
+        - Maintainability
+        - Readability
+        - Performance
+        - Multiple (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Code Location
+      placeholder: File path(s), module(s), or area of the codebase that should be refactored.
+    validations:
+      required: true
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      placeholder: Describe how the code currently works and why it needs refactoring.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed Change
+      placeholder: Describe the refactor you have in mind and why it would be an improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Expected Benefits
+      placeholder: What improvements will this refactor bring? (e.g., reduced complexity, faster execution, easier testing)
+  - type: textarea
+    id: risks
+    attributes:
+      label: Potential Risks or Trade-offs
+      placeholder: Are there any risks, breaking changes, or trade-offs to consider?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context, code snippets, or references here.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing Issues
+      options:
+        - label: I have looked for similar issues and couldn't find any.
+          required: true
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this refactor?"
+      options:
+        - "Yes"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your suggestion! We will review it as soon as possible.


### PR DESCRIPTION
## Related issues

Fixes #968 

## Screenshots and Video Recordings

Checkout demo for issues templates

[Screencast From 2026-02-26 18-48-05.webm](https://github.com/user-attachments/assets/fa8c492d-a81a-432f-9321-16723dce6a5b)

<img width="972" height="468" alt="Screenshot From 2026-02-26 18-22-42" src="https://github.com/user-attachments/assets/ec79fc93-383b-413e-b47c-3fcc22c6d0b4" />


### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added four new standardized issue submission templates for bug reports, feature requests, documentation updates, and refactor suggestions.
  * Each template includes structured forms with guided fields and required validations to ensure consistent, high-quality issue submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->