### PR TITLE
fix: disable logout on GET to prevent CSRF logout attacks

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -272,7 +272,9 @@ ACCOUNT_SESSION_REMEMBER = None  # Let user decide via checkbox
 ACCOUNT_REMEMBER_ME_FIELD = "remember"  # Match test field name
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
-ACCOUNT_LOGOUT_ON_GET = True
+# SECURITY: Must be False. Setting True allows any page to log out users
+# via a GET request (e.g. <img src="/accounts/logout/">), a CSRF attack vector.
+ACCOUNT_LOGOUT_ON_GET = False
 ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = False
 ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = False
 ACCOUNT_OLD_PASSWORD_FIELD_ENABLED = True


### PR DESCRIPTION
<!-- Please customize the sections below to describe your changes. Pull requests that don't fill out this template may be closed without further notice. -->

<!-- Link the issue using the "Fixes" keyword. Example: Fixes #1234 -->

## Related issues

`ACCOUNT_LOGOUT_ON_GET = True` allows any website to silently log out a
logged-in user by embedding a simple ``<image>`` tag:

```html
<img src="https://alphaonelabs.com/accounts/logout/">
```

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [x] Did you run the pre-commit?
- [x] Did you test the change?
- [ ] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout security by restricting logout requests to POST method only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->