### PR TITLE
Fix: CodeQL analysis failing after repo rename

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,3 +100,4 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+        source-root: ${{ github.workspace }}


### PR DESCRIPTION

### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)

### The repo was recently renamed from `alphaonelabs-education-website` to `website`. This caused the CodeQL Perform CodeQL Analysis step to fail with:

Invalid working directory: `/home/runner/work/alphaonelabs-education-website/alphaonelabs-education-website`
 ### CodeQL was inferring the working directory from the old repo name in its internal metadata.

### Fixed by explicitly passing `source-root: ${{ github.workspace }}` to the analyze step, which forces it to use the actual current checkout path regardless of repo name.


> failing in one of my PR: [886](https://github.com/alphaonelabs/website/pull/886)
<img width="1054" height="348" alt="Screenshot 2026-03-02 at 3 29 01 PM" src="https://github.com/user-attachments/assets/1ba283d0-e726-47c1-b47d-75660365ebe8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code analysis configuration to improve the precision and coverage of automated code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->