### PR TITLE
fix: contributor list is visible in dark mode on hover

### DIFF
--- a/web/templates/web/contributors_list.html
+++ b/web/templates/web/contributors_list.html
@@ -120,7 +120,7 @@
       </div>
       <div class="divide-y divide-gray-200 dark:divide-gray-700">
         {% for contributor in contributors %}
-          <div class="p-6 hover:bg-gray-50 dark:hover:bg-gray-750 transition duration-150">
+          <div class="p-6 hover:bg-gray-100 dark:hover:!bg-gray-700 transition-colors duration-200">
             <div class="flex flex-col md:flex-row md:items-center">
               <div class="flex items-center mb-4 md:mb-0">
                 <!-- Avatar -->


### PR DESCRIPTION
- Fixed the visibility issue on hover of contributor list

**Before:**

https://github.com/user-attachments/assets/97520bf1-d5b7-4a5b-90e8-1cd7272e75d7


**After:**

https://github.com/user-attachments/assets/4b8365ed-a4d4-49b0-8763-008462d4c233



<!-- Link the issue using the "Fixes" keyword. Example: Fixes #1234 -->

## Related issues

Fixes #<ISSUE_NUMBER>

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved contributor list hover interactions with enhanced visual feedback and smoother transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->