### PR TITLE
feat: add search autocomplete dropdown for mobile navbar

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -544,6 +544,8 @@
               <div class="relative mb-6">
                 <form action="{% url 'course_search' %}" method="get" class="m-0">
                   <input type="text"
+                         id="search-input-mobile"
+                         autocomplete="off"
                          name="q"
                          placeholder="What do you want to learn?"
                          class="w-full rounded-full bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-300 dark:focus:ring-teal-700" />
@@ -552,6 +554,7 @@
                     <i class="fas fa-search"></i>
                   </button>
                 </form>
+              <div id="autocomplete-dropdown-mobile" role="listbox" aria-label="Course suggestions" class="absolute z-50 w-full bg-white dark:bg-gray-800 rounded-lg shadow-lg mt-1 hidden border border-gray-200 dark:border-gray-700"></div>
               </div>
               <!-- Mobile Navigation Menu with Accordions -->
               <div class="space-y-4">
@@ -1119,5 +1122,72 @@
     </script>
     {% block extra_js %}
     {% endblock extra_js %}
+<script>
+(function() {
+    const input = document.getElementById('search-input-mobile');
+    const dropdown = document.getElementById('autocomplete-dropdown-mobile');
+    if (!input || !dropdown) return;
+
+    let debounceTimer;
+    let currentController = null;
+
+    input.addEventListener('input', function() {
+        clearTimeout(debounceTimer);
+        const query = this.value.trim();
+        if (query.length < 2) {
+            if (currentController) { currentController.abort(); currentController = null; }
+            dropdown.classList.add('hidden');
+            dropdown.innerHTML = '';
+            return;
+        }
+        debounceTimer = setTimeout(() => {
+            if (currentController) currentController.abort();
+            currentController = new AbortController();
+            fetch("{% url 'search_autocomplete' %}" + '?q=' + encodeURIComponent(query), { signal: currentController.signal })
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.results || data.results.length === 0) {
+                        dropdown.classList.add('hidden');
+                        dropdown.innerHTML = '';
+                        return;
+                    }
+                    dropdown.replaceChildren();
+                    data.results.forEach((item) => {
+                        const a = document.createElement('a');
+                        a.href = item.url;
+                        a.setAttribute('role', 'option');
+                        a.setAttribute('aria-selected', 'false');
+                        a.className = 'flex items-center px-4 py-2 hover:bg-teal-50 dark:hover:bg-gray-700 text-sm text-gray-800 dark:text-gray-200 border-b border-gray-100 dark:border-gray-700 last:border-0';
+                        const icon = document.createElement('i');
+                        icon.className = 'fas fa-book-open mr-2 text-teal-500 text-xs';
+                        const title = document.createElement('span');
+                        title.className = 'font-medium';
+                        title.textContent = item.title;
+                        const teacher = document.createElement('span');
+                        teacher.className = 'ml-auto text-xs text-gray-400';
+                        teacher.textContent = item.teacher;
+                        a.append(icon, title, teacher);
+                        dropdown.appendChild(a);
+                    });
+                    dropdown.classList.remove('hidden');
+                })
+                .catch(() => {
+                    dropdown.classList.add('hidden');
+                    dropdown.replaceChildren();
+                });
+        }, 250);
+    });
+
+    document.addEventListener('click', function(e) {
+        if (!input.contains(e.target) && !dropdown.contains(e.target)) {
+            dropdown.classList.add('hidden');
+        }
+    });
+
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') dropdown.classList.add('hidden');
+    });
+})();
+</script>
   </body>
 </html>


### PR DESCRIPTION
Extends the search autocomplete feature to the mobile navigation menu.

- `web/templates/base.html`: added `id` and `autocomplete="off"` to mobile search input, dropdown container inside relative parent, debounced fetch with AbortController, safe DOM construction, ARIA roles, Escape/outside-click dismissal

Reuses the existing `search_autocomplete` endpoint — no backend changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile search gains autocomplete suggestions as you type, integrated into the mobile menu. Suggestions show icons, course titles, and teacher names and become active after 2+ characters. Results are clickable to navigate directly, and the suggestion dropdown can be dismissed by clicking outside or pressing Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->