### PR TITLE
fix: remove duplicate "Learning Requests" label in mobile navigation …

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -628,7 +628,7 @@
                     <a href="{% url 'surveys' %}"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md ">
                       <i class="fas fa-square-poll-vertical mr-2 text-teal-500"></i>
-                      <span>Learning Requests</span>
+                      <span>Surveys</span>
                     </a>
                     <a href="{% url 'waiting_room_list' %}"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">


### PR DESCRIPTION
<!-- Please customize the sections below to describe your changes. Pull requests that don't fill out this template may be closed without further notice. -->

<!-- Link the issue using the "Fixes" keyword. Example: Fixes #1234 -->

## Related issues

Fixes #1001


<img width="1919" height="882" alt="Screenshot 2026-03-10 013905" src="https://github.com/user-attachments/assets/eddfcdeb-79a0-41ff-a49a-be43dbd4e242" />


### Checklist

- [x] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [x] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [x] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a duplicate "Learning Requests" label in the mobile navigation menu's COMMUNITY section by correcting the mislabeled "Surveys" menu item.

## Changes Made
**File: `web/templates/base.html`**
- Changed the display label for the surveys menu item from "Learning Requests" to "Surveys" (line 631)
- The link URL was already correct (`href="{% url 'surveys' %}"`) — only the displayed text needed correction
- No structural or functionality changes

## Impact
- **User Experience**: Mobile users will now see distinct labels ("Learning Requests" and "Surveys") in the COMMUNITY navigation section, matching the intended menu structure
- **Scope**: Minimal — purely cosmetic fix to display text
- **Risk**: Very low — single-line label change with no functional implications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->