### PR TITLE
Fix anonymous user crash in learn form

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -6277,7 +6277,7 @@ def waiting_room_detail(request, waiting_room_id):
         "is_participant": is_participant,
         "is_creator": is_creator,
         "is_teacher": is_teacher,
-        "participant_count": waiting_room.participants.count() + 1,  # Add 1 to include the creator
+       "participant_count": waiting_room.participants.count() + (1 if waiting_room.creator_id else 0),
         "topic_list": [topic.strip() for topic in waiting_room.topics.split(",") if topic.strip()],
     }
     return render(request, "waiting_room/detail.html", context)


### PR DESCRIPTION
<!-- Please customize the sections below to describe your changes. Pull requests that don't fill out this template may be closed without further notice. -->

<!-- Link the issue using the "Fixes" keyword. Example: Fixes #1234 -->

## Related issues

Fixes #<ISSUE_NUMBER>

### Checklist

<!-- Complete the checklist below. Replace the dots inside [.] as follows: -->
<!-- [x] done, [ ] not done, [/ ] not applicable -->

- [ ] Did you run the pre-commit? (If not, your PR will most likely not pass — please ensure it passes pre-commit)
- [ ] Did you test the change? (Ensure you didn’t just prompt the AI and blindly commit — test the code and confirm it works)
- [ ] Added screenshots to the PR description (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a crash occurring when anonymous users submit the learn form to create a waiting room.

## Changes

- web/views.py:
  - In learn(request), assign waiting_room.creator only when request.user.is_authenticated (prevents assigning AnonymousUser).
  - In waiting_room_detail, adjust participant_count calculation to include the creator only when a creator exists (replaces unconditional +1).

## Impact

- Anonymous users can submit the learn form without causing a crash; waiting rooms created by anonymous users will have creator unset (None).
- Authenticated users continue to be recorded as the waiting room creator.
- Participant counts for waiting rooms now correctly account for a missing creator, preventing incorrect counts for anonymous-created rooms.

## Testing Notes

- PR description contains the repository template checklist but no completed items; pre-commit checks and manual tests have not been confirmed.
- Single commit message: "fix participant count logic for anonymous rooms" — aligns with the changes above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->