### PR TITLE
feat: add notification center with unread badge and mark-as-read

### DIFF
--- a/web/context_processors.py
+++ b/web/context_processors.py
@@ -19,5 +19,9 @@ def last_modified(request):
 def invitation_notifications(request):
     if request.user.is_authenticated:
         pending_invites = request.user.received_group_invites.filter(status="pending").count()
-        return {"pending_invites_count": pending_invites}
+        unread_notifications = request.user.notifications.filter(read=False).count()
+        return {
+            "pending_invites_count": pending_invites,
+            "unread_notifications_count": unread_notifications,
+        }
     return {}

--- a/web/templates/account/notifications.html
+++ b/web/templates/account/notifications.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Notifications{% endblock title %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8 max-w-3xl">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+      <i class="fas fa-bell mr-2 text-teal-500"></i> Notifications
+      {% if unread_count %}
+        <span class="ml-2 text-sm font-medium bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200 px-2 py-0.5 rounded-full">
+          {{ unread_count }} unread
+        </span>
+      {% endif %}
+    </h1>
+    {% if unread_count %}
+      <form method="post" action="{% url 'mark_notifications_read' %}">
+        {% csrf_token %}
+        <input type="hidden" name="filter_type" value="{{ filter_type }}">
+        <input type="hidden" name="page" value="{{ page_obj.number }}">
+        <button type="submit"
+                class="text-sm px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-lg transition-colors duration-200">
+          Mark all as read
+        </button>
+      </form>
+    {% endif %}
+  </div>
+
+  <!-- Filter Tabs -->
+  <div class="flex gap-2 mb-6 flex-wrap">
+    <a href="{% url 'notification_list' %}"
+       class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors duration-200
+              {% if not filter_type %}bg-teal-600 text-white{% else %}bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600{% endif %}">
+      All
+    </a>
+    {% for type, label in notification_types %}
+      <a href="{% url 'notification_list' %}?type={{ type }}"
+         class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors duration-200
+                {% if filter_type == type %}bg-teal-600 text-white{% else %}bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600{% endif %}">
+        {{ label }}
+      </a>
+    {% endfor %}
+  </div>
+
+  <!-- Notification List -->
+  <div class="space-y-3">
+    {% for notification in page_obj %}
+      <div class="flex items-start gap-4 p-4 rounded-lg border transition-colors duration-200
+                  {% if not notification.read %}bg-teal-50 dark:bg-teal-900/20 border-teal-200 dark:border-teal-800{% else %}bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700{% endif %}">
+        <!-- Icon -->
+        <div class="flex-shrink-0 mt-0.5">
+          {% if notification.notification_type == "success" %}
+            <i class="fas fa-check-circle text-green-500 text-lg"></i>
+          {% elif notification.notification_type == "warning" %}
+            <i class="fas fa-exclamation-triangle text-yellow-500 text-lg"></i>
+          {% elif notification.notification_type == "error" %}
+            <i class="fas fa-times-circle text-red-500 text-lg"></i>
+          {% else %}
+            <i class="fas fa-info-circle text-teal-500 text-lg"></i>
+          {% endif %}
+        </div>
+        <!-- Content -->
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center justify-between gap-2">
+            <p class="font-semibold text-gray-900 dark:text-white text-sm">{{ notification.title }}</p>
+            <span class="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+              {{ notification.created_at|timesince }} ago
+            </span>
+          </div>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mt-1">{{ notification.message }}</p>
+        </div>
+        <!-- Mark as read -->
+        {% if not notification.read %}
+          <form method="post" action="{% url 'mark_single_notification_read' notification.id %}">
+            {% csrf_token %}
+            <input type="hidden" name="filter_type" value="{{ filter_type }}">
+            <input type="hidden" name="page" value="{{ page_obj.number }}">
+            <button type="submit"
+                    title="Mark as read"
+                    aria-label="Mark notification as read"
+                    class="flex-shrink-0 text-teal-500 hover:text-teal-700 transition-colors duration-200">
+              <i class="fas fa-check text-sm"></i>
+            </button>
+          </form>
+        {% endif %}
+      </div>
+    {% empty %}
+      <div class="text-center py-16 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <i class="fas fa-bell-slash text-4xl text-gray-300 dark:text-gray-600 mb-4"></i>
+        <p class="text-gray-500 dark:text-gray-400 font-medium">No notifications yet</p>
+        <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">You're all caught up!</p>
+      </div>
+    {% endfor %}
+  </div>
+  <!-- Pagination -->
+  {% if page_obj.has_other_pages %}
+    <div class="flex justify-center gap-2 mt-6">
+      {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}{% if filter_type %}&type={{ filter_type }}{% endif %}"
+           class="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-teal-300">
+          Previous
+        </a>
+      {% endif %}
+      <span class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+      </span>
+      {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}{% if filter_type %}&type={{ filter_type }}{% endif %}"
+           class="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-teal-300">
+          Next
+        </a>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>
+{% endblock content %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -375,13 +375,14 @@
                 </span>
               {% endif %}
             </a>
-            <!-- New Notification Button for Invitations -->
-            <a href="{% url 'user_invitations' %}"
-               class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg">
+            <!-- Notification Center Button -->
+            <a href="{% url 'notification_list' %}"
+               class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg"
+               title="Notifications">
               <i class="fas fa-bell"></i>
-              {% if pending_invites_count %}
+              {% if unread_notifications_count %}
                 <span class="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-600 flex items-center justify-center text-white text-xs">
-                  {{ pending_invites_count }}
+                  {{ unread_notifications_count }}
                 </span>
               {% endif %}
             </a>

--- a/web/urls.py
+++ b/web/urls.py
@@ -33,6 +33,9 @@ from .views import (
     features_page,
     grade_link,
     notification_preferences,
+    notification_list,
+    mark_notifications_read,
+    mark_single_notification_read,
     sales_analytics,
     sales_data,
     streak_detail,
@@ -91,6 +94,13 @@ urlpatterns += i18n_patterns(
     path("accounts/signup/", views.signup_view, name="account_signup"),  # Our custom signup view
     path("accounts/", include("allauth.urls")),
     path("account/notification-preferences/", notification_preferences, name="notification_preferences"),
+    path("account/notifications/", notification_list, name="notification_list"),
+    path("account/notifications/mark-all-read/", mark_notifications_read, name="mark_notifications_read"),
+    path(
+        "account/notifications/<int:notification_id>/read/",
+        mark_single_notification_read,
+        name="mark_single_notification_read",
+    ),
     path("profile/", views.profile, name="profile"),
     path("accounts/profile/", views.profile, name="accounts_profile"),
     path("accounts/delete/", views.delete_account, name="delete_account"),

--- a/web/views.py
+++ b/web/views.py
@@ -46,6 +46,7 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse, reverse_lazy
 from django.utils import timezone
@@ -6946,6 +6947,84 @@ def award_badge(request):
     except Exception as e:
         logger.exception("Error awarding badge: %s", str(e))
         return JsonResponse({"success": False, "message": "An internal error occurred"}, status=500)
+
+
+@login_required
+def notification_list(request):
+    """Display all notifications for the current user.
+
+    Args:
+        request: HttpRequest object.
+
+    Returns:
+        Rendered notification center page with notifications.
+    """
+    from django.core.paginator import Paginator
+    filter_type = request.GET.get("type", "")
+    notifications = request.user.notifications.all()
+    valid_types = [t[0] for t in Notification.NOTIFICATION_TYPES]
+    if filter_type in valid_types:
+        notifications = notifications.filter(notification_type=filter_type)
+    paginator = Paginator(notifications, 20)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+    context = {
+        "page_obj": page_obj,
+        "filter_type": filter_type,
+        "unread_count": request.user.notifications.filter(read=False).count(),
+        "notification_types": Notification.NOTIFICATION_TYPES,
+    }
+    return render(request, "account/notifications.html", context)
+
+
+@login_required
+@require_POST
+def mark_notifications_read(request):
+    """Mark all notifications as read for the current user.
+
+    Args:
+        request: HttpRequest object.
+
+    Returns:
+        Redirect back to notification center.
+    """
+    from django.utils import timezone
+    request.user.notifications.filter(read=False).update(read=True, updated_at=timezone.now())
+    filter_type = request.POST.get("filter_type", "")
+    page = request.POST.get("page", "")
+    params = []
+    if filter_type:
+        params.append(f"type={filter_type}")
+    if page:
+        params.append(f"page={page}")
+    query = f"?{'&'.join(params)}" if params else ""
+    return redirect(f"{reverse('notification_list')}{query}")
+
+
+@login_required
+@require_POST
+def mark_single_notification_read(request, notification_id):
+    """Mark a single notification as read.
+
+    Args:
+        request: HttpRequest object.
+        notification_id: ID of the notification to mark as read.
+
+    Returns:
+        Redirect back to notification center.
+    """
+    notification = get_object_or_404(Notification, id=notification_id, user=request.user)
+    notification.read = True
+    notification.save()
+    filter_type = request.POST.get("filter_type", "")
+    page = request.POST.get("page", "")
+    params = []
+    if filter_type:
+        params.append(f"type={filter_type}")
+    if page:
+        params.append(f"page={page}")
+    query = f"?{'&'.join(params)}" if params else ""
+    return redirect(f"{reverse('notification_list')}{query}")
 
 
 def notification_preferences(request):


### PR DESCRIPTION
Adds a dedicated notification center page for authenticated users.

Changes:
- web/context_processors.py: added unread_notifications_count to global template context
- web/views.py: added notification_list, mark_notifications_read, and mark_single_notification_read views
- web/urls.py: added 3 new URL patterns for the notification center
- web/templates/base.html: updated bell icon to link to notification center with unread count badge
- web/templates/account/notifications.html: new template with notification list, filter tabs by type, mark all as read, and mark single as read

Features:
- View all notifications in one place
- Unread count badge on the navbar bell icon
- Filter notifications by type (info, success, warning, error)
- Mark individual notifications as read
- Mark all notifications as read at once
- Empty state when no notifications exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Purpose
Adds a notification center for authenticated users with a global unread-count badge, filtering by notification type, and actions to mark notifications read individually or in bulk.

## Key Changes

Backend
- web/context_processors.py: invitation_notifications now includes unread_notifications_count (count of Notification objects with read=False) in the template context for authenticated users while preserving pending_invites_count.
- web/views.py:
  - notification_list(request): new view that renders the notification center, supports optional type filtering (uses Notification.NOTIFICATION_TYPES), includes unread count, and paginates results (20 per page).
  - mark_notifications_read(request): POST-only endpoint (uses @require_POST) that marks all unread notifications as read for the current user, sets updated_at=timezone.now(), and redirects back to the notification list preserving an optional filter_type.
  - mark_single_notification_read(request, notification_id): POST-only endpoint (uses @require_POST) that marks a single notification as read, sets updated_at=timezone.now(), and redirects back preserving the optional filter_type.
  - Views explicitly pass NOTIFICATION_TYPES into context (avoids relying on page_obj.object_list.model for empty querysets) and use reverse('notification_list') for redirects. Filter_type is preserved via hidden inputs so actions redirect to the active filtered view.

Routing
- web/urls.py: adds three routes:
  - /account/notifications/ → notification_list
  - /account/notifications/mark-all-read/ → mark_notifications_read
  - /account/notifications/<int:notification_id>/read/ → mark_single_notification_read

Frontend
- web/templates/base.html: replaces the invitation-specific bell link with a link to the notification center and shows unread_notifications_count in the navbar badge (title added).
- web/templates/account/notifications.html: new template providing:
  - unread badge and "Mark all as read" action,
  - filter tabs (All + types from NOTIFICATION_TYPES) with active filter preserved,
  - paginated list of notifications with type-specific icons, title, relative timestamp, message, per-notification "Mark as read" form,
  - empty-state UI,
  - pagination controls preserving filter_type in links,
  - accessibility: icon-only mark-as-read button includes aria-label="Mark notification as read".
- Styling tweak: info notification icon color adjusted to match project palette.

## Impact
- UX: Central notification hub accessible from the navbar bell with an unread badge; users can filter by type and mark notifications read individually or in bulk. Filter selection is preserved after mark-as-read actions and pagination.
- Behavior: Introduces read-state mutation endpoints (POST-only) and a global unread count surfaced in templates.
- Performance/DB: Context processor introduces an extra COUNT query for unread notifications; author recommended adding a DB index on (user, read) to improve scale (not part of this PR).
- Safety: Endpoints enforce POST for state changes and preserve filter context on redirects; CSRF/auth protections are expected to apply as with other account actions.

## Notes / Remaining Items
- Minor UX/accessibility/style items (exact color choices, whether the filter nav should be a landmark, bell icon aria-label text) were acknowledged and intentionally deferred to avoid scope creep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->