### PR TITLE
Markdown Sanitization - XSS

### DIFF
--- a/tests/test_markdown_filters.py
+++ b/tests/test_markdown_filters.py
@@ -1,0 +1,102 @@
+from django.test import TestCase
+
+from web.templatetags.markdown_filters import markdownify_sanitized
+
+
+class MarkdownFiltersSanitizationTests(TestCase):
+    """
+    Regression tests covering the sanitizer boundary around the markdownify_sanitized function.
+    """
+
+    def test_markdownify_sanitized_strips_scripts_and_dangerous_tags(self):
+        """Ensure <script>, <iframe>, <embed>, <object> tags and dangerous attributes are stripped."""
+        # Test script tag removal (note: bleach keeps text content by default)
+        sanitized = markdownify_sanitized('<script>alert("XSS")</script>')
+        self.assertNotIn("<script>", sanitized)
+        self.assertIn('alert("XSS")', sanitized)
+
+        # Test attribute removal (onerror, onload, onclick)
+        sanitized_img = markdownify_sanitized('<img src="x" onerror="alert(1)" onload="alert(2)">')
+        self.assertIn('src="x"', sanitized_img)
+        self.assertNotIn("onerror", sanitized_img)
+        self.assertNotIn("onload", sanitized_img)
+
+        sanitized_p = markdownify_sanitized('<p onclick="alert(1)">Click me</p>')
+        self.assertIn("Click me", sanitized_p)
+        self.assertNotIn("onclick", sanitized_p)
+
+        # Test dangerous tags that are not in SAFE_TAGS
+        # Note: markdownify might wrap the result in <p> tags
+        dangerous_payloads = [
+            ('<iframe src="javascript:alert(1)"></iframe>', ""),
+            ('<embed src="evil.swf">', ""),
+            ('<object data="evil.swf"></object>', ""),
+        ]
+        for payload, expected in dangerous_payloads:
+            sanitized = markdownify_sanitized(payload)
+            self.assertNotIn("<iframe", sanitized)
+            self.assertNotIn("<embed", sanitized)
+            self.assertNotIn("<object", sanitized)
+
+    def test_markdownify_sanitized_enforces_protocols(self):
+        """Ensure only allowed protocols (http, https, mailto) are permitted."""
+        test_cases = [
+            ("[JS](javascript:alert(1))", "<a>JS</a>"),
+            ("[Data](data:text/html,xss)", "<a>Data</a>"),
+            ("[HTTP](http://example.com)", '<a href="http://example.com">HTTP</a>'),
+            ("[HTTPS](https://example.com)", '<a href="https://example.com">HTTPS</a>'),
+            ("[Mail](mailto:test@example.com)", '<a href="mailto:test@example.com">Mail</a>'),
+        ]
+        for markdown_input, expected_substring in test_cases:
+            self.assertIn(expected_substring, markdownify_sanitized(markdown_input))
+
+    def test_markdownify_sanitized_preserves_legitimate_markdown(self):
+        """Ensure standard Markdown features are preserved and correctly rendered."""
+        # Links and Images
+        self.assertIn('<a href="http://example.com">Link</a>', markdownify_sanitized("[Link](http://example.com)"))
+
+        # Images (attributes might be reordered)
+        sanitized_img = markdownify_sanitized("![Alt](http://example.com/img.png)")
+        self.assertIn('src="http://example.com/img.png"', sanitized_img)
+        self.assertIn('alt="Alt"', sanitized_img)
+
+        # Tables
+        table_md = "| Head |\n| --- |\n| Cell |"
+        rendered = markdownify_sanitized(table_md)
+        self.assertIn("<table>", rendered)
+        self.assertIn("<thead>", rendered)
+        self.assertIn("<tbody>", rendered)
+        self.assertIn("<td>Cell</td>", rendered)
+
+        # Fenced Code Blocks
+        code_md = "```python\nprint(1)\n```"
+        rendered = markdownify_sanitized(code_md)
+        self.assertIn('<pre><code class="language-python">', rendered)
+        self.assertIn("print(1)", rendered)
+
+        # Blockquotes and Headings
+        self.assertIn("<blockquote>", markdownify_sanitized("> Quote"))
+        self.assertIn("<h1>Title</h1>", markdownify_sanitized("# Title"))
+
+    def test_markdownify_sanitized_handles_empty_input(self):
+        """Ensure empty or None input returns an empty string."""
+        self.assertEqual(markdownify_sanitized(""), "")
+        self.assertEqual(markdownify_sanitized(None), "")
+
+    def test_markdownify_sanitized_preview_flow(self):
+        """
+        Simulate the markdownify sanitized preview flow (AJAX-like).
+        Ensures that even complex payloads passed directly to the function are sanitized.
+        """
+        complex_payload = "Check this [link](javascript:alert(1)) and <script>console.log('x')</script>."
+        sanitized = markdownify_sanitized(complex_payload)
+        self.assertIn("<a>link</a>", sanitized)
+        self.assertNotIn("<script>", sanitized)
+        self.assertNotIn("javascript:", sanitized)
+        self.assertIn("console.log('x')", sanitized)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/web/settings.py
+++ b/web/settings.py
@@ -523,6 +523,10 @@ MARKDOWNX_URLS_PATH = "/markdownx/markdownify/"
 MARKDOWNX_UPLOAD_URLS_PATH = "/markdownx/upload/"
 MARKDOWNX_MEDIA_PATH = "markdownx/"  # Path within MEDIA_ROOT
 
+
+MARKDOWNX_MARKDOWNIFY_FUNCTION = "web.templatetags.markdown_filters.markdownify_sanitized"
+
+
 USE_X_FORWARDED_HOST = True
 
 # GitHub API Token for fetching contributor data

--- a/web/static/js/markdown_preview.js
+++ b/web/static/js/markdown_preview.js
@@ -1,0 +1,39 @@
+/**
+ * Helper function to get CSRF token from cookies
+ */
+function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim();
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+/**
+ * Custom preview renderer for EasyMDE that uses the sanitized server-side endpoint.
+ * @param {string} plainText The raw markdown text from the editor.
+ * @param {string} previewUrl The URL of the markdownify endpoint.
+ * @returns {string} The sanitized HTML from the server.
+ */
+function sanitizedPreviewRender(plainText, previewUrl) {
+    const formData = new FormData();
+    formData.append('content', plainText);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', previewUrl, false); // Synchronous request as required by EasyMDE
+    xhr.setRequestHeader('X-CSRFToken', getCookie('csrftoken'));
+    xhr.send(formData);
+
+    if (xhr.status === 200) {
+        return xhr.responseText;
+    }
+
+    return '<p style="color: red;">Error rendering markdown preview.</p>';
+}

--- a/web/templates/courses/create.html
+++ b/web/templates/courses/create.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+  <script src="{% static 'js/markdown_preview.js' %}"></script>
   {{ form.media }}
 {% endblock extra_head %}
 {% block content %}
@@ -102,7 +103,8 @@
                   minHeight: '100px',
                   maxHeight: '400px',
                   placeholder: textarea.getAttribute('placeholder') || 'Enter your content here...',
-                  autoDownloadFontAwesome: false
+                  autoDownloadFontAwesome: false,
+                  previewRender: (plainText) => sanitizedPreviewRender(plainText, '{% url "markdownx_markdownify" %}')
               });
 
               // Store the editor instance

--- a/web/templates/courses/update.html
+++ b/web/templates/courses/update.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+  <script src="{% static 'js/markdown_preview.js' %}"></script>
   {{ form.media }}
 {% endblock extra_head %}
 {% block content %}
@@ -72,24 +73,7 @@
                       'guide'
                   ],
                   theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
-                  // Use language-agnostic URL
-                  previewRender: function(plainText) {
-                      // Create a temporary form
-                      const formData = new FormData();
-                      formData.append('content', plainText);
-
-                      // Use a synchronous request to get the rendered HTML
-                      const xhr = new XMLHttpRequest();
-                      xhr.open('POST', '{% url "markdownx_markdownify" %}', false); // synchronous request
-                      xhr.setRequestHeader('X-CSRFToken', getCookie('csrftoken'));
-                      xhr.send(formData);
-
-                      if (xhr.status === 200) {
-                          return xhr.responseText;
-                      }
-
-                      return 'Error rendering markdown';
-                  }
+                  previewRender: (plainText) => sanitizedPreviewRender(plainText, '{% url "markdownx_markdownify" %}')
               });
 
               // Store the editor instance

--- a/web/templates/courses/update.html
+++ b/web/templates/courses/update.html
@@ -85,22 +85,6 @@
               });
           });
 
-          // Helper function to get CSRF token from cookies
-          function getCookie(name) {
-              let cookieValue = null;
-              if (document.cookie && document.cookie !== '') {
-                  const cookies = document.cookie.split(';');
-                  for (let i = 0; i < cookies.length; i++) {
-                      const cookie = cookies[i].trim();
-                      if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                          break;
-                      }
-                  }
-              }
-              return cookieValue;
-          }
-
           // Fix form submission for hidden required textareas
           const form = document.getElementById('updateCourseForm');
           form.addEventListener('submit', function(event) {

--- a/web/templates/success_stories/create.html
+++ b/web/templates/success_stories/create.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+  <script src="{% static 'js/markdown_preview.js' %}"></script>
   {{ form.media }}
   <link rel="stylesheet" href="{% static 'css/markdown.css' %}" />
 {% endblock extra_head %}
@@ -145,7 +146,8 @@
                       'preview', 'side-by-side', 'fullscreen', '|',
                       'guide'
                   ],
-                  theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+                  theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+                  previewRender: (plainText) => sanitizedPreviewRender(plainText, '{% url "markdownx_markdownify" %}')
               });
 
               // Store the editor instance

--- a/web/templates/success_stories/detail.html
+++ b/web/templates/success_stories/detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
-{% load markdown_filters %}
 
+{% load markdown_filters %}
 {% load static %}
 
 {% block title %}{{ success_story.title }}{% endblock %}

--- a/web/templates/success_stories/detail.html
+++ b/web/templates/success_stories/detail.html
@@ -54,8 +54,9 @@
             </div>
           {% endif %}
         </header>
+        {% load markdown_filters %}
         <!-- Main Content -->
-        <div class="prose prose-orange dark:prose-invert max-w-none">{{ success_story.content|safe }}</div>
+        <div class="prose prose-orange dark:prose-invert max-w-none">{{ success_story.content|markdown }}</div>
         <!-- Share Links -->
         <div class="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold mb-3">Share this success story</h3>

--- a/web/templates/success_stories/detail.html
+++ b/web/templates/success_stories/detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 
 {% load static %}
 
@@ -54,7 +55,6 @@
             </div>
           {% endif %}
         </header>
-        {% load markdown_filters %}
         <!-- Main Content -->
         <div class="prose prose-orange dark:prose-invert max-w-none">{{ success_story.content|markdown }}</div>
         <!-- Share Links -->

--- a/web/templates/teach.html
+++ b/web/templates/teach.html
@@ -17,6 +17,7 @@
   <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
   <!-- Flatpickr JS -->
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="{% static 'js/markdown_preview.js' %}"></script>
   {{ form.media }}
 {% endblock extra_head %}
 {% block content %}
@@ -84,7 +85,8 @@
                   minHeight: '100px',
                   maxHeight: '400px',
                   placeholder: 'Describe your course...',
-                  autoDownloadFontAwesome: false
+                  autoDownloadFontAwesome: false,
+                  previewRender: (plainText) => sanitizedPreviewRender(plainText, '{% url "markdownx_markdownify" %}')
               });
               editors.set(textarea.name, editor);
               editor.codemirror.on('change', () => {

--- a/web/templatetags/markdown_filters.py
+++ b/web/templatetags/markdown_filters.py
@@ -1,5 +1,5 @@
 import bleach
-from typing import Optional
+from typing import Any, Optional
 from django import template
 from django.utils.safestring import mark_safe
 from markdownx.utils import markdownify
@@ -46,7 +46,6 @@ def markdownify_sanitized(content: Optional[str]) -> str:
 
 
 @register.filter
-def markdown(text):
+def markdown(text: str) -> Any:
     """Convert markdown text to sanitized HTML."""
-    clean_html = markdownify_sanitized(text)
-    return mark_safe(clean_html)
+    return mark_safe(markdownify_sanitized(text))

--- a/web/templatetags/markdown_filters.py
+++ b/web/templatetags/markdown_filters.py
@@ -1,11 +1,54 @@
+import bleach
 from django import template
 from django.utils.safestring import mark_safe
 from markdownx.utils import markdownify
 
 register = template.Library()
 
+SAFE_TAGS = {
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "p", "br", "hr",
+    "strong", "em", "b", "i", "u", "del",
+    "ul", "ol", "li",
+    "a",
+    "pre", "code",
+    "blockquote",
+    "table", "thead", "tbody", "tr", "th", "td",
+    "img",
+}
+
+SAFE_ATTRIBUTES = {
+    "a": {"href", "title"},
+    "img": {"src", "alt", "title"},
+    "code": {"class"},
+    "td": {"align"},
+    "th": {"align"},
+}
+
+def markdownify_sanitized(content):
+    """
+    Custom markdownify function that sanitizes the output HTML using bleach.
+    This is used both for template filters and for the markdownx AJAX preview.
+    """
+    if not content:
+        return ""
+
+    # Convert markdown to HTML
+    html = markdownify(content)
+
+    # Sanitize HTML
+    clean_html = bleach.clean(
+        html,
+        tags=SAFE_TAGS,
+        attributes=SAFE_ATTRIBUTES,
+        strip=True
+    )
+
+    return clean_html
+
 
 @register.filter
 def markdown(text):
-    """Convert markdown text to HTML."""
-    return mark_safe(markdownify(text))
+    """Convert markdown text to sanitized HTML."""
+    clean_html = markdownify_sanitized(text)
+    return mark_safe(clean_html)

--- a/web/templatetags/markdown_filters.py
+++ b/web/templatetags/markdown_filters.py
@@ -7,14 +7,34 @@ from markdownx.utils import markdownify
 register = template.Library()
 
 SAFE_TAGS = {
-    "h1", "h2", "h3", "h4", "h5", "h6",
-    "p", "br", "hr",
-    "strong", "em", "b", "i", "u", "del",
-    "ul", "ol", "li",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "br",
+    "hr",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "u",
+    "del",
+    "ul",
+    "ol",
+    "li",
     "a",
-    "pre", "code",
+    "pre",
+    "code",
     "blockquote",
-    "table", "thead", "tbody", "tr", "th", "td",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
     "img",
 }
 
@@ -28,6 +48,7 @@ SAFE_ATTRIBUTES = {
 
 ALLOWED_PROTOCOLS = {"http", "https", "mailto"}
 
+
 def markdownify_sanitized(content: Optional[str]) -> str:
     """
     Custom markdownify function that sanitizes the output HTML using bleach.
@@ -37,11 +58,7 @@ def markdownify_sanitized(content: Optional[str]) -> str:
         return ""
 
     return bleach.clean(
-        markdownify(content),
-        tags=SAFE_TAGS,
-        attributes=SAFE_ATTRIBUTES,
-        protocols=ALLOWED_PROTOCOLS,
-        strip=True
+        markdownify(content), tags=SAFE_TAGS, attributes=SAFE_ATTRIBUTES, protocols=ALLOWED_PROTOCOLS, strip=True
     )
 
 

--- a/web/templatetags/markdown_filters.py
+++ b/web/templatetags/markdown_filters.py
@@ -1,5 +1,6 @@
-import bleach
 from typing import Any, Optional
+
+import bleach
 from django import template
 from django.utils.safestring import mark_safe
 from markdownx.utils import markdownify

--- a/web/templatetags/markdown_filters.py
+++ b/web/templatetags/markdown_filters.py
@@ -1,4 +1,5 @@
 import bleach
+from typing import Optional
 from django import template
 from django.utils.safestring import mark_safe
 from markdownx.utils import markdownify
@@ -25,7 +26,9 @@ SAFE_ATTRIBUTES = {
     "th": {"align"},
 }
 
-def markdownify_sanitized(content):
+ALLOWED_PROTOCOLS = {"http", "https", "mailto"}
+
+def markdownify_sanitized(content: Optional[str]) -> str:
     """
     Custom markdownify function that sanitizes the output HTML using bleach.
     This is used both for template filters and for the markdownx AJAX preview.
@@ -33,18 +36,13 @@ def markdownify_sanitized(content):
     if not content:
         return ""
 
-    # Convert markdown to HTML
-    html = markdownify(content)
-
-    # Sanitize HTML
-    clean_html = bleach.clean(
-        html,
+    return bleach.clean(
+        markdownify(content),
         tags=SAFE_TAGS,
         attributes=SAFE_ATTRIBUTES,
+        protocols=ALLOWED_PROTOCOLS,
         strip=True
     )
-
-    return clean_html
 
 
 @register.filter


### PR DESCRIPTION
# Markdown Sanitization - XSS

## Abstract
This PR remediates Stored and Reflected XSS vulnerabilities in the markdown rendering pipeline by centralizing sanitization using `bleach`.

## Current Problem
The application was vulnerable to script injection in two main areas:

- **Stored XSS**: Success Stories and Course content were rendered using `|safe` without server-side sanitization, allowing malicious tags to execute for all users.
- **Reflected/Self-XSS**: The EasyMDE editor used an unsanitized client-side preview, which could be exploited via social engineering to execute scripts in a teacher's session.

https://github.com/user-attachments/assets/fbad3168-0835-413a-af00-4083fc3d9a1b

## Fixes
A defense-in-depth approach has been implemented:

### 1. Centralized Sanitization 
- Created a `markdownify_sanitized` function in `web/templatetags/markdown_filters.py` using `bleach` to strip malicious tags and attributes while preserving markdown formatting.
- Updated `settings.py` to use this function globally for all `django-markdownx` AJAX previews.

### 2. Template Security
- Replaced dangerous `|safe` instances with a `|markdown` filter that converts and sanitizes content on the server.

### 3. Hardened Editor Previews
- Integrated `static/js/markdown_preview.js` across (I think) all editors (Course, Teach, and Success Stories) to enforce server-side sanitized previews, eliminating the reflected XSS vector.

---

## Verification
Confirmed that payloads such as `<script>` tags and `onerror` attributes are properly stripped while preserving valid markdown content.

https://github.com/user-attachments/assets/a0a84d28-35f1-4f19-9059-9c5e17254e8a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Markdown Sanitization XSS Fixes

This PR centralizes server-side sanitization for markdown rendering to remediate stored and reflected XSS vectors.

### Purpose
Remove stored XSS (templates that rendered raw HTML with |safe) and reflected/self-XSS in EasyMDE previews by routing all markdown rendering through a bleach-based sanitizer on the server.

### Key Changes
- Sanitizer:
  - Added markdownify_sanitized(content) in web/templatetags/markdown_filters.py: converts markdown via markdownify then sanitizes with bleach.clean(..., strip=True) using explicit allowlists (SAFE_TAGS, SAFE_ATTRIBUTES, ALLOWED_PROTOCOLS).
  - Updated the markdown template filter to return mark_safe(markdownify_sanitized(text)).
- Configuration:
  - Set MARKDOWNX_MARKDOWNIFY_FUNCTION = "web.templatetags.markdown_filters.markdownify_sanitized" in web/settings.py so django-markdownx AJAX previews/endpoint use the sanitized function.
- Client-side preview:
  - Added web/static/js/markdown_preview.js with getCookie(name) and sanitizedPreviewRender(plainText, previewUrl) which posts markdown to the server (sets X-CSRFToken) and returns sanitized HTML (or a small error fragment on non-200).
  - Replaced inline synchronous preview XHRs in templates with sanitizedPreviewRender for Course, Teach, and Success Stories editors.
- Templates:
  - Replaced unsafe |safe usages by rendering content via the markdown filter (e.g., success_stories/detail.html now uses {{ success_story.content|markdown }}).
  - Included the new preview script and configured EasyMDE previewRender to call the server-side sanitizer.

### Tests
- Added tests/tests_markdown_filters.py validating that dangerous tags/attributes and disallowed link protocols are stripped while preserving valid markdown features (links, images, tables, code blocks, blockquotes). Also tests empty and None inputs and mixed payload sanitization.

### Impact
- Mitigates stored and reflected XSS in markdown rendering and editor previews by enforcing a server-side bleach allowlist.
- Preserves expected markdown output; previews now depend on backend availability and CSRF handling (synchronous preview XHR remains in the helper).
- Minimal user-facing changes for valid content; preview will show a small error fragment if preview requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->