### PR TITLE
Add error handling for email sending in send_notification

### DIFF
--- a/web/notifications.py
+++ b/web/notifications.py
@@ -28,13 +28,16 @@ def send_notification(user, notification_data):
         "emails/notification.html",
         {"user": user, "notification": notification},
     )
-    send_mail(
-        subject,
-        "",
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        html_message=html_message,
-    )
+    try:
+        send_mail(
+            subject,
+            "",
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+            html_message=html_message,
+        )
+    except Exception as e:
+        logger.error(f"Failed to send notification email to {user.email}: {str(e)}")
     return notification
 
 


### PR DESCRIPTION
This PR improves the robustness of the send_notification function by adding error handling around the email sending logic.

Changes:
- Wrapped send_mail in a try-except block
- Added logging for failures

This ensures that notification creation is not interrupted if email sending fails, improving reliability and consistency with existing patterns in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Changes Made**
The `send_notification()` function in `web/notifications.py` now includes error handling for email sending. The `send_mail()` call has been wrapped in a try-except block that catches any exceptions during email transmission.

**Key Modifications**
- Added a try-except block (lines 31-40) around the `send_mail()` call to gracefully handle email sending failures
- Implemented error logging via `logger.error()` that records both the target user email address and the exception details
- The function continues to return the created `notification` object even if email sending fails

**Purpose & Impact**
This change ensures that notification creation is not interrupted by email service failures, aligning with existing codebase patterns. By catching and logging exceptions rather than allowing them to propagate, the system becomes more resilient. Notifications are successfully persisted to the database regardless of email delivery issues, while detailed error logs enable troubleshooting of email backend problems. This prevents external service failures from disrupting the notification workflow in production environments.

**Technical Details**
- Lines changed: +10/-7
- No changes to exported or public entity declarations
- Estimated review effort: Medium

<!-- end of auto-generated comment: release notes by coderabbit.ai -->