### PR TITLE
fix: resolve dark mode icon timing issue and fix mobile nav Surveys label

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -32,7 +32,7 @@
         }
 
         // Debug flag
-        const DEBUG = true;
+        const DEBUG = false;
 
         // Logging helper
         function log(message) {
@@ -68,20 +68,30 @@
 
         function updateDarkModeIcon() {
             const isDark = document.documentElement.classList.contains('dark');
-            const icon = document.getElementById('darkModeIcon');
             log(`Updating icon. Dark mode is: ${isDark}`);
 
+            // Update desktop icon
+            const icon = document.getElementById('darkModeIcon');
             if (icon) {
                 icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
                 icon.title = isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode';
                 log('Icon updated successfully');
-            } else {
-                log('Warning: Dark mode icon element not found');
+            }
+
+            // Update mobile icon
+            const mobileIcon = document.getElementById('darkModeIconMobile');
+            if (mobileIcon) {
+                mobileIcon.className = isDark ? 'fas fa-sun mr-2 text-teal-500' : 'fas fa-moon mr-2 text-teal-500';
             }
         }
 
-        // Initialize dark mode immediately and after DOM content loads
-        initializeDarkMode();
+        // Apply dark class immediately (before DOM loads) to prevent flash
+        const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
+        if (darkModeEnabled) {
+            document.documentElement.classList.add('dark');
+        }
+
+        // Update icon only after DOM is ready
         document.addEventListener('DOMContentLoaded', initializeDarkMode);
     </script>
     <!-- Font Awesome (Free CDN) -->
@@ -628,7 +638,7 @@
                     <a href="{% url 'surveys' %}"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md ">
                       <i class="fas fa-square-poll-vertical mr-2 text-teal-500"></i>
-                      <span>Learning Requests</span>
+                      <span>Surveys</span>
                     </a>
                     <a href="{% url 'waiting_room_list' %}"
                        class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">


### PR DESCRIPTION
## Problem

Two bugs were found in `web/templates/base.html`:

**Bug 1 — Dark mode icon not found warning**
The `updateDarkModeIcon()` function was called before the DOM finished loading, causing this console warning on every page load : Warning: Dark mode icon element not found
This happened because `initializeDarkMode()` was called immediately in the <head> script, before the icon element existed in the DOM.

**Bug 2 — Mobile nav showed "Learning Requests" instead of "Surveys"**
The Surveys link in the mobile COMMUNITY section was incorrectly labeled as "Learning Requests", causing user confusion.

## Fix

- Separated dark class application (runs immediately to prevent flash) from icon update (runs only after DOMContentLoaded)
- Updated `updateDarkModeIcon()` to also sync the mobile icon (`darkModeIconMobile`)
- Fixed mobile nav label from "Learning Requests" to "Surveys"
- Set DEBUG = false to suppress development logs in production

## Testing

- Verified no console warnings on page load
- Dark mode toggle works correctly on both desktop and mobile
- Mobile nav Community section now shows correct labels
<img width="933" height="383" alt="Screenshot 2026-05-07 at 12 12 51 PM" src="https://github.com/user-attachments/assets/409e7629-73e5-4b7e-a559-f32b4bb74992" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR resolves two dark mode and mobile navigation issues in the base template:

### Issues Fixed

1. **Dark Mode Icon Timing Issue**: Separated the application of the dark class (runs immediately in the `<head>` to prevent flash) from the icon update logic (deferred until `DOMContentLoaded`). This eliminates the console warning "Warning: Dark mode icon element not found" that previously occurred when `updateDarkModeIcon()` was called before the DOM finished loading.

2. **Mobile Navigation Label Bug**: Fixed the Surveys link in the mobile COMMUNITY section, which was incorrectly labeled as "Learning Requests".

### Key Changes

- **Debug Mode**: Set `DEBUG` constant to `false` to suppress development logs in production.
- **Enhanced Icon Updates**: Expanded `updateDarkModeIcon()` function to sync both desktop (`darkModeIcon`) and mobile (`darkModeIconMobile`) dark mode toggle icons.
- **Improved Initialization Flow**: Implemented two-phase dark mode initialization:
  - Inline class application on page load to prevent visual flash
  - Deferred icon updates that execute only after the DOM is ready via `DOMContentLoaded` event listener
- **Corrected Mobile Navigation**: Updated mobile nav COMMUNITY section label to display "Surveys" for the surveys link.

### Verification

Dark mode toggle now works correctly on both desktop and mobile without console warnings, and mobile navigation labels are accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->